### PR TITLE
Feature/15 get mogak

### DIFF
--- a/src/main/java/com/mogak/spring/converter/MogakConverter.java
+++ b/src/main/java/com/mogak/spring/converter/MogakConverter.java
@@ -2,11 +2,15 @@ package com.mogak.spring.converter;
 
 import com.mogak.spring.domain.common.State;
 import com.mogak.spring.domain.common.Validation;
+import com.mogak.spring.domain.common.Weeks;
 import com.mogak.spring.domain.mogak.Mogak;
 import com.mogak.spring.domain.mogak.MogakCategory;
 import com.mogak.spring.domain.user.User;
 import com.mogak.spring.web.dto.MogakRequestDto;
 import com.mogak.spring.web.dto.MogakResponseDto;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class MogakConverter {
 
@@ -34,6 +38,33 @@ public class MogakConverter {
         return MogakResponseDto.updateStateDto.builder()
                 .mogakId(mogak.getId())
                 .updatedAt(mogak.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * 여러 모각 조회
+     * */
+    public static MogakResponseDto.getMogakListDto toGetMogakListDto(List<Mogak> mogaks) {
+        return MogakResponseDto.getMogakListDto.builder()
+                .mogaks(mogaks.stream()
+                        .map(MogakConverter::toGetMogakDto)
+                        .collect(Collectors.toList()))
+                .size(mogaks.size())
+                .build();
+    }
+
+    /**
+     * 단일 모각 조회
+     * */
+    public static MogakResponseDto.getMogakDto toGetMogakDto(Mogak mogak) {
+        return MogakResponseDto.getMogakDto.builder()
+                .title(mogak.getTitle())
+                .state(mogak.getState())
+                .periods(mogak.getPeriod())
+                .mogakCategory(mogak.getCategory())
+                .otherCategory(mogak.getOtherCategory())
+                .startAt(mogak.getStartAt())
+                .endAt(mogak.getEndAt())
                 .build();
     }
 }

--- a/src/main/java/com/mogak/spring/domain/common/Weeks.java
+++ b/src/main/java/com/mogak/spring/domain/common/Weeks.java
@@ -1,0 +1,27 @@
+package com.mogak.spring.domain.common;
+
+public enum Weeks {
+    MONDAY("MON", 1),
+    TUESDAY("TUE", 2),
+    WEDNESDAY("WED", 3),
+    THURSDAY("THU", 4),
+    FRIDAY("FRI", 5),
+    SATURDAY("SAT", 6),
+    SUNDAY("SUN", 7);
+
+    private final String name;
+    private final int value;
+
+    private Weeks(String name, int value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getValue() {
+        return this.value;
+    }
+}

--- a/src/main/java/com/mogak/spring/domain/mogak/Mogak.java
+++ b/src/main/java/com/mogak/spring/domain/mogak/Mogak.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Builder
 @Getter
@@ -25,7 +26,7 @@ public class Mogak extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id")
     private User user;
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name="mogak_category_id")
     private MogakCategory category;
     @Column(name = "category_other")
@@ -41,6 +42,14 @@ public class Mogak extends BaseEntity {
     private LocalDate endAt;
     @Column(nullable = false)
     private String validation;
+
+    public List<String> getPeriod() {
+        return this.getMogakPeriods()
+                .stream()
+                .map(MogakPeriod::getPeriod)
+                .map(Period::getDays)
+                .collect(Collectors.toList());
+    }
 
     public void updateState(String state) {
         this.state = state;

--- a/src/main/java/com/mogak/spring/repository/MogakRepository.java
+++ b/src/main/java/com/mogak/spring/repository/MogakRepository.java
@@ -1,7 +1,11 @@
 package com.mogak.spring.repository;
 
 import com.mogak.spring.domain.mogak.Mogak;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MogakRepository extends JpaRepository<Mogak, Long> {
+    List<Mogak> findAllByUserIdOrderByCreatedAtDesc(Long userId, PageRequest pageRequest);
 }

--- a/src/main/java/com/mogak/spring/service/MogakService.java
+++ b/src/main/java/com/mogak/spring/service/MogakService.java
@@ -3,8 +3,12 @@ package com.mogak.spring.service;
 import com.mogak.spring.domain.mogak.Mogak;
 import com.mogak.spring.web.dto.MogakRequestDto;
 
+import java.util.List;
+
 public interface MogakService {
     Mogak create(MogakRequestDto.CreateDto createDto);
     Mogak achieveMogak(Long id);
     Mogak updateMogak(MogakRequestDto.UpdateDto request);
+
+    List<Mogak> getMogakList(Long userId, int cursor, int size);
 }

--- a/src/main/java/com/mogak/spring/service/MogakServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/MogakServiceImpl.java
@@ -10,6 +10,7 @@ import com.mogak.spring.domain.user.User;
 import com.mogak.spring.repository.*;
 import com.mogak.spring.web.dto.MogakRequestDto;
 import lombok.AllArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -140,5 +141,12 @@ public class MogakServiceImpl implements MogakService {
             updateMogakPeriod(days, mogak);
         }
         return mogak;
+    }
+
+    @Override
+    public List<Mogak> getMogakList(Long userId, int cursor, int size) {
+        User user = userRepository.findById(userId).orElseThrow(RuntimeException::new);
+        PageRequest pageRequest = PageRequest.of(cursor, size);
+        return mogakRepository.findAllByUserIdOrderByCreatedAtDesc(user.getId(), pageRequest);
     }
 }

--- a/src/main/java/com/mogak/spring/web/controller/MogakController.java
+++ b/src/main/java/com/mogak/spring/web/controller/MogakController.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @AllArgsConstructor
 @RestController
 @RequestMapping("/api/mogaks")
@@ -42,6 +44,21 @@ public class MogakController {
     public ResponseEntity<MogakResponseDto.updateStateDto> updateMogak(@RequestBody MogakRequestDto.UpdateDto request) {
         Mogak mogak = mogakService.updateMogak(request);
         return ResponseEntity.status(HttpStatus.OK).body(MogakConverter.toUpdateDto(mogak));
+    }
+
+    /**
+     * 모각 조회 API
+     * user => 유저 PK
+     * cursor => 데이터 조회 시작점
+     * size => 조회할 데이터 개수
+     * */
+    @GetMapping("")
+    public ResponseEntity<MogakResponseDto.getMogakListDto> getMogakList(
+            @RequestParam(value = "user") Long userId,
+            @RequestParam(value = "cursor") int cursor,
+            @RequestParam(value = "size") int size) {
+            List<Mogak> mogaks = mogakService.getMogakList(userId, cursor, size);
+            return ResponseEntity.status(HttpStatus.OK).body(MogakConverter.toGetMogakListDto(mogaks));
     }
 
 }

--- a/src/main/java/com/mogak/spring/web/dto/MogakResponseDto.java
+++ b/src/main/java/com/mogak/spring/web/dto/MogakResponseDto.java
@@ -1,8 +1,13 @@
 package com.mogak.spring.web.dto;
 
+import com.mogak.spring.domain.mogak.Mogak;
+import com.mogak.spring.domain.mogak.MogakCategory;
+import com.mogak.spring.domain.mogak.MogakPeriod;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class MogakResponseDto {
 
@@ -22,5 +27,28 @@ public class MogakResponseDto {
     public static class updateStateDto {
         private Long mogakId;
         private LocalDateTime updatedAt;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class getMogakListDto {
+        private List<getMogakDto> mogaks;
+        private int size;
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor(access = AccessLevel.PROTECTED)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class getMogakDto {
+        private String title;
+        private String state;
+        private List<String> periods;
+        private MogakCategory mogakCategory;
+        private String otherCategory;
+        private LocalDate startAt;
+        private LocalDate endAt;
     }
 }


### PR DESCRIPTION
## 관련 이슈
#15 
## 변경사항
모각 페이징 조회 구현
## 작업 중 발생한 문제점과 해결방안 또는 새롭게 알게된 점
객체를 가져오려하니 다대다 관계에 있던 카테고리에서 순환참조 문제가 발생
-> 순환참조를 끊어 내고자 객체를 객체 그대로 가져오지 않고 Primitive 타입으로 변환해서 
고유의 값만 Dto에 담아서 가져오도록 수행
게다가 프록시 문제가 발생하였다
-> GPT가 FETCH.LAZY를 FETCH.EAGER로 변환해서 수행해보길 권고 했길래 그렇게 수정.
추후에 이 문제에 대해 인지하고 자세히 알아볼 예정
## 논의해봐야할 점
## 기타
