### PR TITLE
[Feat] : 회고록 삭제시 s3이미지, 댓글 연쇄 삭제 (#8)

### DIFF
--- a/src/main/java/com/mogak/spring/converter/PostImgConverter.java
+++ b/src/main/java/com/mogak/spring/converter/PostImgConverter.java
@@ -5,13 +5,15 @@ import com.mogak.spring.domain.post.PostImg;
 import com.mogak.spring.web.dto.PostImgRequestDto;
 import com.mogak.spring.web.dto.PostImgResponseDto;
 
+import java.util.List;
+
 public class PostImgConverter {
     /*
-    public static PostImgResponseDto.CreatePostImgDto toCreatePostImgDto(PostImg postImg){
+    public static PostImgResponseDto.CreatePostImgDto toCreatePostImgDto(PostImg post){
+        return
 
     }
-    */
-
+*/
     public static PostImg toPostImg(PostImgRequestDto.CreatePostImgDto request, Post post){
         return PostImg.builder()
                 .post(post)

--- a/src/main/java/com/mogak/spring/domain/post/Post.java
+++ b/src/main/java/com/mogak/spring/domain/post/Post.java
@@ -7,6 +7,8 @@ import com.mogak.spring.domain.user.User;
 import lombok.*;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 @Getter
@@ -29,6 +31,12 @@ public class Post extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "jogak_id")
     private Jogak jogak;
+    @Builder.Default
+    @OneToMany(mappedBy = "post")
+    private List<PostComment> postComments = new ArrayList<>();
+    @Builder.Default
+    @OneToMany(mappedBy = "post")
+    private List<PostImg> postImgs = new ArrayList<>();
     @Column(nullable = false)
     private String validation;
     @Column(nullable = false)
@@ -40,4 +48,13 @@ public class Post extends BaseEntity {
     public void updatePost(String contents){
         this.contents=contents;
     }
+
+    public void putComment(PostComment postComment){
+        this.postComments.add(postComment);
+    }
+
+    public void putPostImg(PostImg postImg){
+        this.postImgs.add(postImg);
+    }
+
 }

--- a/src/main/java/com/mogak/spring/repository/PostCommentRepository.java
+++ b/src/main/java/com/mogak/spring/repository/PostCommentRepository.java
@@ -1,5 +1,6 @@
 package com.mogak.spring.repository;
 
+import com.mogak.spring.domain.post.Post;
 import com.mogak.spring.domain.post.PostComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -16,4 +17,6 @@ public interface PostCommentRepository extends JpaRepository<PostComment, Long> 
 
     //댓글 삭제
     void deleteByPostAndId(Long postId, Long commentId);
+    //연쇄삭제
+    void deleteAllByPost(Post post);
 }

--- a/src/main/java/com/mogak/spring/repository/PostImgRepository.java
+++ b/src/main/java/com/mogak/spring/repository/PostImgRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 public interface PostImgRepository extends JpaRepository<PostImg, Long> {
 
     List<PostImg> findAllByPost(Post post);
+    void deleteAllByPost(Post post);
 }

--- a/src/main/java/com/mogak/spring/service/AwsS3Service.java
+++ b/src/main/java/com/mogak/spring/service/AwsS3Service.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.mogak.spring.domain.post.PostImg;
 import com.mogak.spring.repository.PostImgRepository;
 import com.mogak.spring.web.dto.PostImgRequestDto;
 import com.mogak.spring.web.dto.PostImgResponseDto;
@@ -55,20 +56,19 @@ public class AwsS3Service {
                     .imgName(imgName)
                     .imgUrl(amazonS3.getUrl(bucket, imgName).toString())
                     .build());
-
         });
         return postImgRequestDtoList;
     }
-    //s3 이미지 delete
-    public void deleteImg(String imgName, String dirName){
-        amazonS3.deleteObject(new DeleteObjectRequest(bucket, dirName + "/" + imgName));
+    //s3 이미지객체 delete
+    public void deleteImg(List<PostImg> postImgList, String dirName){
+        for(PostImg postImg : postImgList){
+            String imgName = postImg.getImgName();
+            amazonS3.deleteObject(new DeleteObjectRequest(bucket, imgName));
+        }
     }
     //파일 업로드할 시 파일명 난수화를 위해 uuid 생성
     private String createImgName(String imgName, String dirName){
         String end = imgName.substring(imgName.indexOf(".")+1); // 이미지 형식 . 뒷부분 추출
         return dirName + "/" + UUID.randomUUID().toString() + "." + end;
     }
-
-
-
 }

--- a/src/main/java/com/mogak/spring/service/PostImgService.java
+++ b/src/main/java/com/mogak/spring/service/PostImgService.java
@@ -1,8 +1,12 @@
 package com.mogak.spring.service;
 
+import com.mogak.spring.domain.post.Post;
+import com.mogak.spring.domain.post.PostImg;
+
 import java.util.List;
 
 public interface PostImgService {
 
     List<String> findUrlByPost(Long postId);
+    List<PostImg> findAllByPost(Post post);
 }

--- a/src/main/java/com/mogak/spring/service/PostImgServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/PostImgServiceImpl.java
@@ -1,7 +1,9 @@
 package com.mogak.spring.service;
 
 import com.mogak.spring.domain.post.Post;
+import com.mogak.spring.domain.post.PostComment;
 import com.mogak.spring.domain.post.PostImg;
+import com.mogak.spring.repository.PostCommentRepository;
 import com.mogak.spring.repository.PostImgRepository;
 import com.mogak.spring.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,4 +31,11 @@ public class PostImgServiceImpl implements PostImgService{
         }
         return imgUrlList;
     }
+
+    @Override
+    public List<PostImg> findAllByPost(Post post){
+        return postImgRepository.findAllByPost(post);
+    }
+
+
 }

--- a/src/main/java/com/mogak/spring/service/PostServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/PostServiceImpl.java
@@ -6,10 +6,7 @@ import com.mogak.spring.domain.mogak.Mogak;
 import com.mogak.spring.domain.post.Post;
 import com.mogak.spring.domain.post.PostImg;
 import com.mogak.spring.domain.user.User;
-import com.mogak.spring.repository.MogakRepository;
-import com.mogak.spring.repository.PostImgRepository;
-import com.mogak.spring.repository.PostRepository;
-import com.mogak.spring.repository.UserRepository;
+import com.mogak.spring.repository.*;
 import com.mogak.spring.web.dto.PostImgRequestDto;
 import com.mogak.spring.web.dto.PostRequestDto;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +25,9 @@ public class PostServiceImpl implements PostService{
     private final MogakRepository mogakRepository;
     private final UserRepository userRepository;
     private final PostImgRepository postImgRepository;
+    private final PostCommentRepository postCommentRepository;
 
-    //회고록 & 회고록 이미지 생성
+    //회고록 & 회고록 이미지 생성 => 리팩토링 필요
     @Transactional
     @Override
     public Post create(PostRequestDto.CreatePostDto request, List<PostImgRequestDto.CreatePostImgDto> postImgDtoList, /*User user,*/Long mogakId){
@@ -44,7 +42,7 @@ public class PostServiceImpl implements PostService{
         return postRepository.save(post);
     }
 
-    //회고록 상세 조회
+    //회고록 상세 조회 + 댓글, 이미지 같이 보이게
     @Override
     public Post findById(Long postId){
         return postRepository.findById(postId).get();
@@ -65,8 +63,13 @@ public class PostServiceImpl implements PostService{
     @Transactional
     @Override
     public void delete(Long postId){
+        Post post = postRepository.findById(postId).get();
+        //이미지 삭제
+        postImgRepository.deleteAllByPost(post);
+        //댓글 삭제
+        postCommentRepository.deleteAllByPost(post);
+        //회고록 삭제
         postRepository.deleteById(postId);
-        return;
     }
 
 }

--- a/src/main/java/com/mogak/spring/web/controller/PostController.java
+++ b/src/main/java/com/mogak/spring/web/controller/PostController.java
@@ -1,7 +1,9 @@
 package com.mogak.spring.web.controller;
 
 import com.mogak.spring.converter.PostConverter;
+import com.mogak.spring.converter.PostImgConverter;
 import com.mogak.spring.domain.post.Post;
+import com.mogak.spring.domain.post.PostImg;
 import com.mogak.spring.domain.user.User;
 import com.mogak.spring.service.AwsS3Service;
 import com.mogak.spring.service.PostImgService;
@@ -30,7 +32,7 @@ public class PostController {
     public ResponseEntity<PostResponseDto.CreatePostDto> createPost(@PathVariable Long mogakId, @RequestPart PostRequestDto.CreatePostDto request, @RequestPart(required = true) List<MultipartFile> multipartFile/*User user*/){
         //에러핸들링 필요
         List<PostImgRequestDto.CreatePostImgDto> postImgDtoList = awsS3Service.uploadImg(multipartFile, dirName);
-        Post post = postService.create(request, postImgDtoList, mogakId); //회고록 생성시 이미지 분리해야할듯
+        Post post = postService.create(request, postImgDtoList, mogakId);
         return ResponseEntity.ok(PostConverter.toCreatePostDto(post));
     }
 
@@ -52,9 +54,12 @@ public class PostController {
         return ResponseEntity.ok(PostConverter.toUpdatePostDto(post));
     }
 
-    //Delete - s3 이미지 삭제도 구현
+    //Delete - s3 이미지 삭제,댓글 삭제도 구현
     @DeleteMapping("/mogaks/posts/{postId}")
     public ResponseEntity<PostResponseDto.DeletePostDto> deletePost(@PathVariable Long postId){
+        Post post = postService.findById(postId);
+        List<PostImg> postImgList = postImgService.findAllByPost(post);
+        awsS3Service.deleteImg(postImgList,dirName); //s3이미지 객체 삭제
         postService.delete(postId);
         return ResponseEntity.ok(PostConverter.toDeletePostDto());
     }


### PR DESCRIPTION
## 관련 이슈
#8 
## 변경사항
회고록 삭제시 s3 이미지 객체와 db , 댓글 연쇄 삭제 구현
post domain에서 이미지, 댓글 양방향 매핑 추가
## 작업 중 발생한 문제점과 해결방안 또는 새롭게 알게된 점
## 논의해봐야할 점
양방향 매핑 추가함으로써 코드 리팩토링 필요할 듯 합니다
서비스에서 다른 서비스 의존 관련 문제 - 조금 더 고민할 필요가 있습니다. 현재는 controller 단에서 로직 구현하는 방향으로 하기는 했으나 더 공부한 뒤 추후 코드 리팩토링 필요할 듯 합니다
## 기타
