### PR TITLE
fix(#132): comment permission counter

### DIFF
--- a/src/main/java/com/mogak/spring/service/PostCommentServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/PostCommentServiceImpl.java
@@ -4,11 +4,11 @@ import com.mogak.spring.converter.CommentConverter;
 import com.mogak.spring.domain.post.Post;
 import com.mogak.spring.domain.post.PostComment;
 import com.mogak.spring.domain.user.User;
+import com.mogak.spring.exception.AuthException;
 import com.mogak.spring.exception.PostCommentException;
 import com.mogak.spring.exception.PostException;
 import com.mogak.spring.exception.UserException;
 import com.mogak.spring.global.ErrorCode;
-import com.mogak.spring.jwt.CustomUserDetails;
 import com.mogak.spring.repository.PostCommentRepository;
 import com.mogak.spring.repository.PostRepository;
 import com.mogak.spring.repository.UserRepository;
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @Transactional
@@ -33,13 +34,9 @@ public class PostCommentServiceImpl implements PostCommentService {
     @Transactional
     @Override
     public PostComment create(CommentRequestDto.CreateCommentDto request, Long postId) {
-        Object principal = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails userDetails = (CustomUserDetails)principal;
-        String email = ((CustomUserDetails) principal).getUsername();
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.NOT_EXIST_POST));
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
+        User user = getCurrentUser();
         if (request.getContents().length() > 200) {
             throw new PostCommentException(ErrorCode.EXCEED_MAX_NUM_COMMENT);
         }
@@ -61,15 +58,10 @@ public class PostCommentServiceImpl implements PostCommentService {
     @Transactional
     @Override
     public PostComment update(CommentRequestDto.UpdateCommentDto request, Long postId, Long commentId) {
-        /**
-         * TODO 유저 확인 체크하는 부분 추가해야함
-         */
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.NOT_EXIST_POST));
-        PostComment comment = postCommentRepository.findByPostAndId(post, commentId);
-        if (comment == null) {
-            throw new PostCommentException(ErrorCode.NOT_EXIST_COMMENT);
-        }
+        PostComment comment = getCommentInPost(post, commentId);
+        validateOwner(comment, getCurrentUser());
         if (request.getContents().length() > 200 ) {
             throw new PostCommentException(ErrorCode.EXCEED_MAX_NUM_COMMENT);
         }
@@ -84,10 +76,30 @@ public class PostCommentServiceImpl implements PostCommentService {
     public void delete(Long postId, Long commentId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(ErrorCode.NOT_EXIST_POST));
-        post.subtractPostLike();
-        PostComment postComment = postCommentRepository.findById(commentId)
-                .orElseThrow(() -> new PostCommentException(ErrorCode.NOT_EXIST_COMMENT));
-        postCommentRepository.deleteByPostAndId(post, commentId);
+        PostComment comment = getCommentInPost(post, commentId);
+        validateOwner(comment, getCurrentUser());
+        post.subtractCommentCnt();
+        postCommentRepository.delete(comment);
+    }
+
+    private User getCurrentUser() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
+    }
+
+    private PostComment getCommentInPost(Post post, Long commentId) {
+        PostComment comment = postCommentRepository.findByPostAndId(post, commentId);
+        if (comment == null) {
+            throw new PostCommentException(ErrorCode.NOT_EXIST_COMMENT);
+        }
+        return comment;
+    }
+
+    private void validateOwner(PostComment comment, User user) {
+        if (!Objects.equals(comment.getUser().getId(), user.getId())) {
+            throw new AuthException(ErrorCode.INVALID_PERMISSION);
+        }
     }
 
 }

--- a/src/main/java/com/mogak/spring/web/controller/CommentController.java
+++ b/src/main/java/com/mogak/spring/web/controller/CommentController.java
@@ -78,8 +78,10 @@ public class CommentController {
                     @Parameter(name = "commentId", description = "댓글 ID"),
             },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "회고록 삭제 성공"),
-                    @ApiResponse(responseCode = "404", description = "존재하지 않는 회고록",
+                    @ApiResponse(responseCode = "200", description = "댓글 수정 성공"),
+                    @ApiResponse(responseCode = "403", description = "댓글 수정 권한 없음",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않은 게시물, 존재하지 않은 댓글",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @PutMapping("/api/posts/{postId}/comments/{commentId}")
@@ -99,6 +101,8 @@ public class CommentController {
             },
             responses = {
                     @ApiResponse(responseCode = "200", description = "댓글 삭제 성공"),
+                    @ApiResponse(responseCode = "403", description = "댓글 삭제 권한 없음",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
                     @ApiResponse(responseCode = "404", description = "존재하지 않은 게시물, 존재하지 않은 댓글",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })

--- a/src/main/java/com/mogak/spring/web/controller/CommentController.java
+++ b/src/main/java/com/mogak/spring/web/controller/CommentController.java
@@ -81,7 +81,7 @@ public class CommentController {
                     @ApiResponse(responseCode = "200", description = "댓글 수정 성공"),
                     @ApiResponse(responseCode = "403", description = "댓글 수정 권한 없음",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "존재하지 않은 게시물, 존재하지 않은 댓글",
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 게시물, 존재하지 않는 댓글",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @PutMapping("/api/posts/{postId}/comments/{commentId}")
@@ -103,7 +103,7 @@ public class CommentController {
                     @ApiResponse(responseCode = "200", description = "댓글 삭제 성공"),
                     @ApiResponse(responseCode = "403", description = "댓글 삭제 권한 없음",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-                    @ApiResponse(responseCode = "404", description = "존재하지 않은 게시물, 존재하지 않은 댓글",
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 게시물, 존재하지 않는 댓글",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @DeleteMapping("/api/posts/{postId}/comments/{commentId}")

--- a/src/test/java/com/mogak/spring/service/PostCommentServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/PostCommentServiceImplTest.java
@@ -1,0 +1,204 @@
+package com.mogak.spring.service;
+
+import com.mogak.spring.domain.post.Post;
+import com.mogak.spring.domain.post.PostComment;
+import com.mogak.spring.domain.user.User;
+import com.mogak.spring.global.ErrorCode;
+import com.mogak.spring.repository.PostCommentRepository;
+import com.mogak.spring.repository.PostRepository;
+import com.mogak.spring.repository.UserRepository;
+import com.mogak.spring.support.ErrorCodeAssertions;
+import com.mogak.spring.support.SecurityContextTestHelper;
+import com.mogak.spring.support.TestFixtureFactory;
+import com.mogak.spring.web.dto.commentdto.CommentRequestDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PostCommentServiceImplTest {
+
+    @Mock
+    private PostCommentRepository postCommentRepository;
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private PostCommentServiceImpl postCommentService;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextTestHelper.clear();
+    }
+
+    @Test
+    @DisplayName("인증 사용자가 댓글을 생성하면 댓글을 저장하고 댓글 수를 증가시킨다")
+    void createUsesAuthenticationNameAndIncrementsCommentCount() {
+        User writer = user(1L, "writer@test.com");
+        Post post = post(10L, writer, 3, 0);
+        CommentRequestDto.CreateCommentDto request = createRequest("새 댓글");
+
+        SecurityContextTestHelper.setAuthentication("writer@test.com");
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(userRepository.findByEmail("writer@test.com")).thenReturn(Optional.of(writer));
+        when(postCommentRepository.save(any(PostComment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PostComment result = postCommentService.create(request, 10L);
+
+        assertThat(result.getPost()).isSameAs(post);
+        assertThat(result.getUser()).isSameAs(writer);
+        assertThat(result.getContents()).isEqualTo("새 댓글");
+        assertThat(post.getCommentCnt()).isEqualTo(1);
+        assertThat(post.getLikeCnt()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("댓글 작성자가 댓글을 수정하면 댓글 내용이 변경된다")
+    void updateChangesCommentWhenOwnerRequests() {
+        User writer = user(1L, "writer@test.com");
+        Post post = post(10L, writer, 3, 1);
+        PostComment comment = comment(100L, post, writer, "기존 댓글");
+
+        SecurityContextTestHelper.setAuthentication("writer@test.com");
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(postCommentRepository.findByPostAndId(post, 100L)).thenReturn(comment);
+        when(userRepository.findByEmail("writer@test.com")).thenReturn(Optional.of(writer));
+
+        PostComment result = postCommentService.update(updateRequest("수정 댓글"), 10L, 100L);
+
+        assertThat(result.getContents()).isEqualTo("수정 댓글");
+        assertThat(comment.getContents()).isEqualTo("수정 댓글");
+    }
+
+    @Test
+    @DisplayName("댓글 작성자가 아닌 사용자가 댓글을 수정하면 권한 예외를 반환하고 내용은 유지된다")
+    void updateThrowsInvalidPermissionWhenNotOwner() {
+        User writer = user(1L, "writer@test.com");
+        User other = user(2L, "other@test.com");
+        Post post = post(10L, writer, 3, 1);
+        PostComment comment = comment(100L, post, writer, "기존 댓글");
+
+        SecurityContextTestHelper.setAuthentication("other@test.com");
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(postCommentRepository.findByPostAndId(post, 100L)).thenReturn(comment);
+        when(userRepository.findByEmail("other@test.com")).thenReturn(Optional.of(other));
+
+        Throwable throwable = catchThrowable(() -> postCommentService.update(updateRequest("수정 댓글"), 10L, 100L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        assertThat(comment.getContents()).isEqualTo("기존 댓글");
+    }
+
+    @Test
+    @DisplayName("댓글 작성자가 아닌 사용자가 댓글을 삭제하면 권한 예외를 반환하고 카운터와 삭제는 실행되지 않는다")
+    void deleteThrowsInvalidPermissionWhenNotOwner() {
+        User writer = user(1L, "writer@test.com");
+        User other = user(2L, "other@test.com");
+        Post post = post(10L, writer, 3, 1);
+        PostComment comment = comment(100L, post, writer, "기존 댓글");
+
+        SecurityContextTestHelper.setAuthentication("other@test.com");
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(postCommentRepository.findByPostAndId(post, 100L)).thenReturn(comment);
+        when(userRepository.findByEmail("other@test.com")).thenReturn(Optional.of(other));
+
+        Throwable throwable = catchThrowable(() -> postCommentService.delete(10L, 100L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        assertThat(post.getCommentCnt()).isEqualTo(1);
+        assertThat(post.getLikeCnt()).isEqualTo(3);
+        verify(postCommentRepository, never()).delete(any(PostComment.class));
+    }
+
+    @Test
+    @DisplayName("게시글과 댓글이 매칭되지 않으면 댓글 없음 예외를 반환하고 카운터는 유지된다")
+    void deleteThrowsNotExistCommentWhenCommentDoesNotBelongToPost() {
+        User writer = user(1L, "writer@test.com");
+        Post post = post(10L, writer, 3, 1);
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(postCommentRepository.findByPostAndId(post, 100L)).thenReturn(null);
+
+        Throwable throwable = catchThrowable(() -> postCommentService.delete(10L, 100L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.NOT_EXIST_COMMENT);
+        assertThat(post.getCommentCnt()).isEqualTo(1);
+        assertThat(post.getLikeCnt()).isEqualTo(3);
+        verify(userRepository, never()).findByEmail(any());
+        verify(postCommentRepository, never()).delete(any(PostComment.class));
+    }
+
+    @Test
+    @DisplayName("댓글 삭제에 성공하면 좋아요 수는 유지하고 댓글 수만 감소시킨 뒤 댓글을 삭제한다")
+    void deleteDecrementsCommentCountOnlyWhenOwnerRequests() {
+        User writer = user(1L, "writer@test.com");
+        Post post = post(10L, writer, 3, 2);
+        PostComment comment = comment(100L, post, writer, "기존 댓글");
+
+        SecurityContextTestHelper.setAuthentication("writer@test.com");
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+        when(postCommentRepository.findByPostAndId(post, 100L)).thenReturn(comment);
+        when(userRepository.findByEmail("writer@test.com")).thenReturn(Optional.of(writer));
+
+        postCommentService.delete(10L, 100L);
+
+        assertThat(post.getCommentCnt()).isEqualTo(1);
+        assertThat(post.getLikeCnt()).isEqualTo(3);
+        verify(postCommentRepository).delete(comment);
+    }
+
+    private static User user(Long id, String email) {
+        return TestFixtureFactory.user(id, email, "user" + id, null, null);
+    }
+
+    private static Post post(Long id, User user, int likeCnt, int commentCnt) {
+        return Post.builder()
+                .id(id)
+                .user(user)
+                .contents("게시글")
+                .postThumbnailUrl("thumbnail")
+                .validation("ACTIVE")
+                .viewCnt(0)
+                .likeCnt(likeCnt)
+                .commentCnt(commentCnt)
+                .build();
+    }
+
+    private static PostComment comment(Long id, Post post, User user, String contents) {
+        return PostComment.builder()
+                .id(id)
+                .post(post)
+                .user(user)
+                .contents(contents)
+                .validation("ACTIVE")
+                .build();
+    }
+
+    private static CommentRequestDto.CreateCommentDto createRequest(String contents) {
+        CommentRequestDto.CreateCommentDto request = new CommentRequestDto.CreateCommentDto();
+        ReflectionTestUtils.setField(request, "contents", contents);
+        return request;
+    }
+
+    private static CommentRequestDto.UpdateCommentDto updateRequest(String contents) {
+        CommentRequestDto.UpdateCommentDto request = new CommentRequestDto.UpdateCommentDto();
+        ReflectionTestUtils.setField(request, "contents", contents);
+        return request;
+    }
+}


### PR DESCRIPTION
## 해결하려던 문제 혹은 구현하려는 기능
- 댓글 수정/삭제 시 현재 인증 사용자와 댓글 작성자 권한을 검증하도록 수정
- 댓글 삭제 시 좋아요 수가 아니라 댓글 수만 감소하도록 카운터 갱신 로직 수정
- 댓글 수정/삭제 OpenAPI 응답 문서에 403 권한 실패 케이스 추가

## Changes
- `PostCommentServiceImpl`에서 인증 사용자 조회를 `Authentication#getName()` 기반으로 통일
- `update/delete`에서 `findByPostAndId(post, commentId)`로 게시글-댓글 매칭을 먼저 검증
- 비작성자 요청은 `ErrorCode.INVALID_PERMISSION`으로 실패 처리
- 게시글과 댓글이 매칭되지 않으면 `ErrorCode.NOT_EXIST_COMMENT`로 실패하고 카운터를 변경하지 않도록 보장
- 댓글 삭제 성공 시 `subtractCommentCnt()` 호출 후 조회된 댓글 엔티티를 삭제
- `PostCommentServiceImplTest` 추가로 권한/카운터 회귀 테스트 보강

## 관련 이슈
#132