### PR TITLE
chore(#134): JWT/JAXB 의존성 정리 및 Spring JOSE 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ dependencies {
 	// Security and auth
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client'
+	implementation 'org.springframework.security:spring-security-oauth2-jose'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
-	implementation 'com.nimbusds:nimbus-jose-jwt:9.30.1'
 	implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,13 +46,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client'
 	implementation 'org.springframework.security:spring-security-oauth2-jose'
-	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
 	// Persistence
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 
 	// Storage and media
 	implementation "software.amazon.awssdk:s3"

--- a/src/main/java/com/mogak/spring/auth/AppleClaimsValidator.java
+++ b/src/main/java/com/mogak/spring/auth/AppleClaimsValidator.java
@@ -24,7 +24,7 @@ public class AppleClaimsValidator {
     public boolean isValid(Jwt claims) {
         String issuer = claims.getClaimAsString("iss");
         return issuer != null &&
-                issuer.contains(iss) &&
+                iss.equals(issuer) &&
                 claims.getAudience().contains(clientId);
     }
 }

--- a/src/main/java/com/mogak/spring/auth/AppleClaimsValidator.java
+++ b/src/main/java/com/mogak/spring/auth/AppleClaimsValidator.java
@@ -1,7 +1,7 @@
 package com.mogak.spring.auth;
 
-import io.jsonwebtoken.Claims;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 
 /*
@@ -9,25 +9,22 @@ claims 검증(id token 파싱 후)
  */
 @Component
 public class AppleClaimsValidator {
-    private static final String NONCE_KEY = "nonce";
 
     private final String iss;
     private final String clientId;
-//    private final String nonce;
 
     public AppleClaimsValidator(
             @Value("${oauth.apple.iss}") String iss,
             @Value("${oauth.apple.client-id}") String clientId
-//            @Value("${oauth.apple.nonce}") String nonce
     ) {
         this.iss = iss;
         this.clientId = clientId;
-//        this.nonce = EncryptUtils.encrypt(nonce);
     }
 
-    public boolean isValid(Claims claims) {
-        return claims.getIssuer().contains(iss) &&
-                claims.getAudience().equals(clientId);
-//                claims.get(NONCE_KEY, String.class).equals(nonce);
+    public boolean isValid(Jwt claims) {
+        String issuer = claims.getClaimAsString("iss");
+        return issuer != null &&
+                issuer.contains(iss) &&
+                claims.getAudience().contains(clientId);
     }
 }

--- a/src/main/java/com/mogak/spring/auth/AppleJwtParser.java
+++ b/src/main/java/com/mogak/spring/auth/AppleJwtParser.java
@@ -1,16 +1,26 @@
 package com.mogak.spring.auth;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mogak.spring.exception.AuthException;
 import com.mogak.spring.exception.BaseException;
 import com.mogak.spring.global.ErrorCode;
-import io.jsonwebtoken.*;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.stereotype.Component;
 
 import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
 import java.util.Base64;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /*
 identy token에서 alg, kid 추출 -> id_token를 public key로 파싱
@@ -30,8 +40,9 @@ public class AppleJwtParser {
         try {
             String encodedHeader = identityToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
             String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
-            return OBJECT_MAPPER.readValue(decodedHeader, Map.class);
-        } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) { //Token header가 올바르지 않으면 예외발생
+            return OBJECT_MAPPER.readValue(decodedHeader, new TypeReference<>() {
+            });
+        } catch (JsonProcessingException | IllegalArgumentException | ArrayIndexOutOfBoundsException e) { //Token header가 올바르지 않으면 예외발생
             throw new BaseException(ErrorCode.INVALID_APPLE_ID_TOKEN);
         }
     }
@@ -39,16 +50,33 @@ public class AppleJwtParser {
     /*
     id token 파싱
      */
-    public Claims parsePublicKeyAndGetClaims(String idToken, PublicKey publicKey) {
+    public Jwt parsePublicKeyAndGetClaims(String idToken, PublicKey publicKey) {
+        if (!(publicKey instanceof RSAPublicKey rsaPublicKey)) {
+            throw new BaseException(ErrorCode.WRONG_APPLE_PUBLIC_KEY);
+        }
         try {
-            return Jwts.parser()
-                    .setSigningKey(publicKey)
-                    .parseClaimsJws(idToken)
-                    .getBody();
-        } catch (ExpiredJwtException e) {
-            throw new BaseException(ErrorCode.EXPIRE_APPLE_ID_TOKEN);
-        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
+            NimbusJwtDecoder decoder = NimbusJwtDecoder.withPublicKey(rsaPublicKey)
+                    .signatureAlgorithm(SignatureAlgorithm.RS256)
+                    .validateType(false)
+                    .build();
+            decoder.setJwtValidator(new JwtTimestampValidator(Duration.ZERO));
+            return decoder.decode(idToken);
+        } catch (JwtValidationException e) {
+            if (isExpired(e)) {
+                throw new BaseException(ErrorCode.EXPIRE_APPLE_ID_TOKEN);
+            }
+            throw new BaseException(ErrorCode.INVALID_APPLE_ID_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
             throw new BaseException(ErrorCode.INVALID_APPLE_ID_TOKEN);
         }
+    }
+
+    private boolean isExpired(JwtValidationException exception) {
+        return exception.getErrors()
+                .stream()
+                .map(OAuth2Error::getDescription)
+                .filter(Objects::nonNull)
+                .map(description -> description.toLowerCase(Locale.ROOT))
+                .anyMatch(description -> description.contains("expired"));
     }
 }

--- a/src/main/java/com/mogak/spring/auth/AppleJwtParser.java
+++ b/src/main/java/com/mogak/spring/auth/AppleJwtParser.java
@@ -14,6 +14,7 @@ import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
 import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Duration;
@@ -30,6 +31,7 @@ public class AppleJwtParser {
 
     private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
     private static final int HEADER_INDEX = 0;
+    private static final Duration APPLE_ID_TOKEN_CLOCK_SKEW = Duration.ofSeconds(30);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -39,7 +41,7 @@ public class AppleJwtParser {
     public Map<String, String> parseHeaders(String identityToken) {
         try {
             String encodedHeader = identityToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
-            String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
+            String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader), StandardCharsets.UTF_8);
             return OBJECT_MAPPER.readValue(decodedHeader, new TypeReference<>() {
             });
         } catch (JsonProcessingException | IllegalArgumentException | ArrayIndexOutOfBoundsException e) { //Token header가 올바르지 않으면 예외발생
@@ -59,7 +61,7 @@ public class AppleJwtParser {
                     .signatureAlgorithm(SignatureAlgorithm.RS256)
                     .validateType(false)
                     .build();
-            decoder.setJwtValidator(new JwtTimestampValidator(Duration.ZERO));
+            decoder.setJwtValidator(new JwtTimestampValidator(APPLE_ID_TOKEN_CLOCK_SKEW));
             return decoder.decode(idToken);
         } catch (JwtValidationException e) {
             if (isExpired(e)) {

--- a/src/main/java/com/mogak/spring/auth/AppleOAuthUserProvider.java
+++ b/src/main/java/com/mogak/spring/auth/AppleOAuthUserProvider.java
@@ -1,10 +1,9 @@
 package com.mogak.spring.auth;
 
 import com.mogak.spring.exception.BaseException;
-import com.mogak.spring.exception.UserException;
 import com.mogak.spring.global.ErrorCode;
-import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 
 import java.security.PublicKey;
@@ -28,12 +27,12 @@ public class AppleOAuthUserProvider {
 
         PublicKey publicKey = publicKeyGenerator.generatePublicKey(headers, applePublicKeys);
 
-        Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
+        Jwt claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
         validateClaims(claims);
-        return new AppleUserResponse(claims.get("email", String.class));
+        return new AppleUserResponse(claims.getClaimAsString("email"));
     }
 
-    private void validateClaims(Claims claims) {
+    private void validateClaims(Jwt claims) {
         if (!appleClaimsValidator.isValid(claims)) {
             throw new BaseException(ErrorCode.NOT_VALID_APPLE_CLAIMS) {
             };

--- a/src/main/java/com/mogak/spring/jwt/JwtInterceptor.java
+++ b/src/main/java/com/mogak/spring/jwt/JwtInterceptor.java
@@ -33,7 +33,7 @@ public class JwtInterceptor implements HandlerInterceptor {
             log.info("token이 존재하지 않습니다");
             throw new BaseException(ErrorCode.EMPTY_TOKEN);
         }
-        log.info("현재 accesstoken : " + accessToken);
+        log.info("access token이 존재합니다");
         //토큰 확인되면  유저 정보 받아오고 authectication 객체 저장
         if (jwtTokenProvider.validateAccessToken(accessToken)) {//access token 검증
             setAuthentication(accessToken);

--- a/src/main/java/com/mogak/spring/jwt/JwtInterceptor.java
+++ b/src/main/java/com/mogak/spring/jwt/JwtInterceptor.java
@@ -1,21 +1,16 @@
 package com.mogak.spring.jwt;
 
-import com.mogak.spring.exception.AuthException;
 import com.mogak.spring.exception.BaseException;
 import com.mogak.spring.global.ErrorCode;
 import feign.Request;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.SignatureException;
-import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * request를 intercept해 jwt 검증
@@ -32,25 +27,17 @@ public class JwtInterceptor implements HandlerInterceptor {
         if (preflight(request)) {
             return true;
         }
-        try {
-            //헤더에서 토큰 받아옴
-            String accessToken = jwtTokenProvider.resolveAccessToken(request);
-            if (accessToken == null) {
-                log.info("token이 존재하지 않습니다");
-                throw new BaseException(ErrorCode.EMPTY_TOKEN);
-            }
-            log.info("현재 accesstoken : " + accessToken);
-            //토큰 확인되면  유저 정보 받아오고 authectication 객체 저장
-            if (jwtTokenProvider.validateAccessToken(accessToken)) {//access token 검증
-                setAuthentication(accessToken);
-                log.info("인증 성공");
-            }
-        } catch (ExpiredJwtException e) {//만료기간 체크
-            log.info("만료된 토큰입니다");
-            throw new AuthException(ErrorCode.EXPIRE_TOKEN);
-        } catch (SignatureException | UnsupportedJwtException | AuthException e) { //기존서명확인불가&jwt 구조 문제
-            log.info("잘못된 토큰입니다");
-            throw new AuthException(ErrorCode.WRONG_TOKEN);
+        //헤더에서 토큰 받아옴
+        String accessToken = jwtTokenProvider.resolveAccessToken(request);
+        if (accessToken == null) {
+            log.info("token이 존재하지 않습니다");
+            throw new BaseException(ErrorCode.EMPTY_TOKEN);
+        }
+        log.info("현재 accesstoken : " + accessToken);
+        //토큰 확인되면  유저 정보 받아오고 authectication 객체 저장
+        if (jwtTokenProvider.validateAccessToken(accessToken)) {//access token 검증
+            setAuthentication(accessToken);
+            log.info("인증 성공");
         }
         return true;
     }

--- a/src/main/java/com/mogak/spring/jwt/JwtTokenCodec.java
+++ b/src/main/java/com/mogak/spring/jwt/JwtTokenCodec.java
@@ -30,6 +30,7 @@ public class JwtTokenCodec {
 
     private static final int MIN_HMAC_SHA_256_KEY_BYTES = 32;
     private static final String HMAC_SHA_256 = "HmacSHA256";
+    static final Duration JWT_CLOCK_SKEW = Duration.ofSeconds(30);
 
     private final JwtEncoder jwtEncoder;
     private final JwtDecoder jwtDecoder;
@@ -42,7 +43,7 @@ public class JwtTokenCodec {
         NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(secretKey)
                 .macAlgorithm(MacAlgorithm.HS256)
                 .build();
-        decoder.setJwtValidator(new JwtTimestampValidator(Duration.ZERO));
+        decoder.setJwtValidator(new JwtTimestampValidator(JWT_CLOCK_SKEW));
         this.jwtDecoder = decoder;
     }
 

--- a/src/main/java/com/mogak/spring/jwt/JwtTokenCodec.java
+++ b/src/main/java/com/mogak/spring/jwt/JwtTokenCodec.java
@@ -1,0 +1,91 @@
+package com.mogak.spring.jwt;
+
+import com.mogak.spring.exception.AuthException;
+import com.mogak.spring.global.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+import java.util.Locale;
+import java.time.Duration;
+import java.util.Objects;
+
+@Component
+public class JwtTokenCodec {
+
+    private static final int MIN_HMAC_SHA_256_KEY_BYTES = 32;
+    private static final String HMAC_SHA_256 = "HmacSHA256";
+
+    private final JwtEncoder jwtEncoder;
+    private final JwtDecoder jwtDecoder;
+
+    public JwtTokenCodec(@Value("${jwt.secret}") String encodedSecret) {
+        SecretKey secretKey = createSecretKey(encodedSecret);
+        this.jwtEncoder = NimbusJwtEncoder.withSecretKey(secretKey)
+                .algorithm(MacAlgorithm.HS256)
+                .build();
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(secretKey)
+                .macAlgorithm(MacAlgorithm.HS256)
+                .build();
+        decoder.setJwtValidator(new JwtTimestampValidator(Duration.ZERO));
+        this.jwtDecoder = decoder;
+    }
+
+    public String encode(JwtClaimsSet claimsSet) {
+        JwsHeader jwsHeader = JwsHeader.with(MacAlgorithm.HS256)
+                .type("jwt")
+                .build();
+        return jwtEncoder.encode(JwtEncoderParameters.from(jwsHeader, claimsSet))
+                .getTokenValue();
+    }
+
+    public Jwt decode(String token) {
+        try {
+            return jwtDecoder.decode(token);
+        } catch (JwtValidationException exception) {
+            if (isExpired(exception)) {
+                throw new AuthException(ErrorCode.EXPIRE_TOKEN);
+            }
+            throw new AuthException(ErrorCode.WRONG_TOKEN);
+        } catch (JwtException | IllegalArgumentException exception) {
+            throw new AuthException(ErrorCode.WRONG_TOKEN);
+        }
+    }
+
+    private SecretKey createSecretKey(String encodedSecret) {
+        byte[] decodedSecret;
+        try {
+            decodedSecret = Base64.getDecoder().decode(encodedSecret);
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalStateException("jwt.secret must be a Base64-encoded HMAC key", exception);
+        }
+        if (decodedSecret.length < MIN_HMAC_SHA_256_KEY_BYTES) {
+            throw new IllegalStateException("jwt.secret must decode to at least 32 bytes for HS256");
+        }
+        return new SecretKeySpec(decodedSecret, HMAC_SHA_256);
+    }
+
+    private boolean isExpired(JwtValidationException exception) {
+        return exception.getErrors()
+                .stream()
+                .map(OAuth2Error::getDescription)
+                .filter(Objects::nonNull)
+                .map(description -> description.toLowerCase(Locale.ROOT))
+                .anyMatch(description -> description.contains("expired"));
+    }
+}

--- a/src/main/java/com/mogak/spring/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/mogak/spring/jwt/JwtTokenFilter.java
@@ -1,11 +1,11 @@
 package com.mogak.spring.jwt;
 
-import com.mogak.spring.exception.AuthException;
 import com.mogak.spring.exception.BaseException;
 import com.mogak.spring.global.ErrorCode;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.SignatureException;
-import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -13,10 +13,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Arrays;
 
@@ -31,21 +27,12 @@ public class JwtTokenFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
         String accessToken = jwtTokenProvider.resolveAccessToken(request);
-        log.info("현재 accessToken : " + accessToken);
-        try {
-            if(accessToken==null){
-                throw new BaseException(ErrorCode.EMPTY_TOKEN);
-            }
-            if(jwtTokenProvider.validateAccessToken(accessToken)){//access token 검증
-                setAuthentication(accessToken); //검증된 토큰만 securitycontextholder에 토큰 등록
-                log.info("인증 성공");
-            }
-        } catch (ExpiredJwtException e){//만료기간 체크
-            log.info("만료된 토큰입니다");
-            throw new BaseException(ErrorCode.EXPIRE_TOKEN);
-        } catch (SignatureException | UnsupportedJwtException | AuthException e){ //기존서명확인불가&jwt 구조 문제
-            log.info("잘못된 토큰입니다");
-            throw new BaseException(ErrorCode.WRONG_TOKEN);
+        if (accessToken == null) {
+            throw new BaseException(ErrorCode.EMPTY_TOKEN);
+        }
+        if (jwtTokenProvider.validateAccessToken(accessToken)) {
+            setAuthentication(accessToken);
+            log.info("인증 성공");
         }
         filterChain.doFilter(request, response);
     }
@@ -58,17 +45,13 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
-    /**
-     * 해당 uri는 filter x
-     */
-
     @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+    protected boolean shouldNotFilter(HttpServletRequest request) {
         String[] excludePath = {"/","/swagger-ui/**", "/v3/api-docs", "/swagger-resources/**",
                 "/webjars/**", "/swagger-ui.html", "/swagger-ui/index.html","/api-docs/**",
                 "/api/auth/login","/api/auth/refresh","/api/auth/logout",
                 "/api/users/nickname/verify","/api/users/join"};
-        String path=request.getRequestURI();
+        String path = request.getRequestURI();
         return Arrays.stream(excludePath).anyMatch(path::startsWith);
     }
 }

--- a/src/main/java/com/mogak/spring/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/mogak/spring/jwt/JwtTokenProvider.java
@@ -1,6 +1,5 @@
 package com.mogak.spring.jwt;
 
-import com.mogak.spring.exception.AuthException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -66,13 +65,9 @@ public class JwtTokenProvider {
         return jwtTokenCodec.decode(token);
     }
 
-    public boolean isExpired(String token, Date date) {
-        try {
-            Jwt claims = parseToken(token);
-            return claims.getExpiresAt() != null && !claims.getExpiresAt().isBefore(date.toInstant()); //만료시간이 현재시간 이전이 아니라면 true, 만료되었다면 false
-        } catch (AuthException e) {
-            throw e;
-        }
+    public boolean isNotExpiredAt(String token, Date date) {
+        Jwt claims = parseToken(token);
+        return claims.getExpiresAt() != null && !claims.getExpiresAt().plus(JwtTokenCodec.JWT_CLOCK_SKEW).isBefore(date.toInstant());
     }
 
     public Authentication getAuthentication(String token) {
@@ -106,7 +101,7 @@ public class JwtTokenProvider {
      */
     public JwtTokens refresh(String refreshToken, Long userId, String email) {
         Date date = new Date();
-        if (!isExpired(refreshToken, date)) { //만료되었으면
+        if (!isNotExpiredAt(refreshToken, date)) {
             throw new IllegalStateException("EXPIRED_REFRESH_TOKEN");
         }
         String accessToken = createAccessToken(userId, email);
@@ -135,6 +130,6 @@ public class JwtTokenProvider {
         Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Asia/Seoul"), Locale.KOREA);
         calendar.setTime(new Date());
         calendar.add(Calendar.DATE, 3);//현재시간으로부터 3일 후까지 리프레시 가능하도록
-        return !isExpired(refreshToken, calendar.getTime());
+        return !isNotExpiredAt(refreshToken, calendar.getTime());
     }
 }

--- a/src/main/java/com/mogak/spring/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/mogak/spring/jwt/JwtTokenProvider.java
@@ -1,19 +1,17 @@
 package com.mogak.spring.jwt;
 
 import com.mogak.spring.exception.AuthException;
-import com.mogak.spring.exception.BaseException;
-import com.mogak.spring.global.ErrorCode;
-import io.jsonwebtoken.*;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
@@ -23,68 +21,57 @@ import java.util.TimeZone;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    @Value("${jwt.secret}")
-    private String secretKey;
     @Value("${jwt.access-token-expiry}")
     private Long accessTokenValidTime;
     @Value("${jwt.refresh-token-expiry}")
     private Long refreshTokenValidTime;
     private final CustomUserDetailsService userDetailsService;
+    private final JwtTokenCodec jwtTokenCodec;
 
     public static final String access_header = "Authorization";
     public static final String refresh_header = "RefreshToken";
 
     public String createAccessToken(Long userId, String email) {
-        Date now = new Date();
-        return Jwts.builder()
-                .setHeaderParam("type", "jwt")
+        java.time.Instant now = java.time.Instant.now();
+        return jwtTokenCodec.encode(org.springframework.security.oauth2.jwt.JwtClaimsSet.builder()
                 .claim("id", userId)
                 .claim("email", email)
-                .setSubject(email)
-                .setIssuedAt(now)
-                .setExpiration(new Date(System.currentTimeMillis() + accessTokenValidTime))
-                .signWith(SignatureAlgorithm.HS256, secretKey)
-                .compact();
+                .subject(email)
+                .issuedAt(now)
+                .expiresAt(now.plusMillis(accessTokenValidTime))
+                .build());
     }
 
     public String createRefreshToken(String email) {
-        Date now = new Date();
-        return Jwts.builder()
-                .setSubject(email)
-                .setIssuedAt(now)
-                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenValidTime))
-                .signWith(SignatureAlgorithm.HS256, secretKey)
-                .compact();
+        java.time.Instant now = java.time.Instant.now();
+        return jwtTokenCodec.encode(org.springframework.security.oauth2.jwt.JwtClaimsSet.builder()
+                .subject(email)
+                .issuedAt(now)
+                .expiresAt(now.plusMillis(refreshTokenValidTime))
+                .build());
     }
 
     /**
      * access token 검증
      */
     public boolean validateAccessToken(String accessToken) {
-        try {
-            parseToken(accessToken);
-        } catch (ExpiredJwtException e) {
-            throw new AuthException(ErrorCode.EXPIRE_TOKEN);
-        } catch (SignatureException | UnsupportedJwtException e) {
-            throw new AuthException(ErrorCode.WRONG_TOKEN);
-        }
+        parseToken(accessToken);
         return true;
     }
 
     /**
      * claims 추출
      */
-    public Jws<Claims> parseToken(String token) {
-        Jws<Claims> jws = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
-        return jws;
+    public Jwt parseToken(String token) {
+        return jwtTokenCodec.decode(token);
     }
 
     public boolean isExpired(String token, Date date) {
         try {
-            Jws<Claims> claims = parseToken(token);
-            return !claims.getBody().getExpiration().before(date); //만료시간이 현재시간 이전이 아니라면 true, 만료되었다면 false
-        } catch (Exception e) {
-            throw new BaseException(ErrorCode.EXPIRE_TOKEN);
+            Jwt claims = parseToken(token);
+            return claims.getExpiresAt() != null && !claims.getExpiresAt().isBefore(date.toInstant()); //만료시간이 현재시간 이전이 아니라면 true, 만료되었다면 false
+        } catch (AuthException e) {
+            throw e;
         }
     }
 
@@ -111,8 +98,7 @@ public class JwtTokenProvider {
 
     //user email 검색
     public String getUserPk(String token) {
-        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
-                .getBody().get("email").toString();
+        return parseToken(token).getClaimAsString("email");
     }
 
     /**
@@ -138,14 +124,8 @@ public class JwtTokenProvider {
     /**
      * refresh 토큰 이메일 추출
      */
-    public String getEmailByRefresh(String refreshToken) throws JwtException {
-        try {
-            Jws<Claims> claims = parseToken(refreshToken);
-            String email = claims.getBody().getSubject();
-            return email;
-        } catch (JwtException e) {
-            throw new JwtException("Invalid Refresh Token");
-        }
+    public String getEmailByRefresh(String refreshToken) {
+        return parseToken(refreshToken).getSubject();
     }
 
     /**

--- a/src/main/java/com/mogak/spring/login/JwtTokenHandler.java
+++ b/src/main/java/com/mogak/spring/login/JwtTokenHandler.java
@@ -2,11 +2,9 @@ package com.mogak.spring.login;
 
 import com.mogak.spring.exception.BaseException;
 import com.mogak.spring.global.ErrorCode;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import org.springframework.beans.factory.annotation.Value;
+import com.mogak.spring.jwt.JwtTokenCodec;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -15,33 +13,30 @@ import org.springframework.web.util.WebUtils;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Optional;
 
 @Component
+@RequiredArgsConstructor
 public class JwtTokenHandler {
 
-    @Value("${jwt.secret}")
-    private String secretKey;
+    private final JwtTokenCodec jwtTokenCodec;
 
     public static final String AUTHORIZATION = "Authorization";
 
     private final long TOKEN_VALID_TIME = 1000L * 60 * 60 * 24 * 365; // 24시간 * 30 => 한달
 
     public String createJwtToken(String userPk) {
-        Date now = new Date();
-        return Jwts.builder()
-                .setHeaderParam("type","jwt")
-                .claim("userPk", userPk)
-                .setIssuedAt(now)
-                .setExpiration(new Date(System.currentTimeMillis() + TOKEN_VALID_TIME))
-                .signWith(SignatureAlgorithm.HS256, secretKey)
-                .compact();
+        Instant now = Instant.now();
+        return jwtTokenCodec.encode(JwtClaimsSet.builder()
+                .claim("id", userPk)
+                .issuedAt(now)
+                .expiresAt(now.plusMillis(TOKEN_VALID_TIME))
+                .build());
     }
 
     public String getUserPk(String token) {
-        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token)
-                .getBody().get("userPk", String.class);
+        return jwtTokenCodec.decode(token).getClaimAsString("id");
     }
 
     public String resolveAccessToken(HttpServletRequest request) {
@@ -57,14 +52,7 @@ public class JwtTokenHandler {
     }
 
     public void validateToken(String token) {
-        try {
-            token = parseToken(token);
-            if (!validateExpireToken(token)) {
-                throw new BaseException(ErrorCode.EXPIRE_TOKEN);
-            }
-        } catch (RuntimeException e) {
-            throw new BaseException(ErrorCode.WRONG_TOKEN);
-        }
+        jwtTokenCodec.decode(parseToken(token));
     }
 
     private String parseToken(String token) {
@@ -72,18 +60,6 @@ public class JwtTokenHandler {
             return token.substring("Bearer ".length());
         }
         throw new BaseException(ErrorCode.WRONG_TOKEN);
-    }
-
-    /**
-     * 토큰 만료 검증
-     * */
-    private boolean validateExpireToken(String jwtToken) {
-        try {
-            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
-            return !claims.getBody().getExpiration().before(new Date());
-        } catch (Exception e) {
-            throw new BaseException(ErrorCode.EXPIRE_TOKEN);
-        }
     }
 
     public Long getUserId() {

--- a/src/test/java/com/mogak/spring/auth/AppleClaimsValidatorTest.java
+++ b/src/test/java/com/mogak/spring/auth/AppleClaimsValidatorTest.java
@@ -29,11 +29,23 @@ public class AppleClaimsValidatorTest {
     }
 
     @Test
-    @DisplayName("URL로 변환할 수 없는 issuer는 false를 반환한다")
-    void returnsFalseWhenIssuerCannotBeConvertedToUrl() {
+    @DisplayName("issuer가 기대값이 아니면 false를 반환한다")
+    void returnsFalseWhenIssuerDoesNotMatchExpectedValue() {
         Jwt claims = Jwt.withTokenValue("token")
                 .header("alg", "RS256")
                 .claim("iss", "not-apple")
+                .claim("aud", java.util.List.of(CLIENT_ID))
+                .build();
+
+        assertThat(appleClaimsValidator.isValid(claims)).isFalse();
+    }
+
+    @Test
+    @DisplayName("issuer가 Apple issuer를 포함하더라도 정확히 일치하지 않으면 false를 반환한다")
+    void returnsFalseWhenIssuerOnlyContainsExpectedValue() {
+        Jwt claims = Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .claim("iss", ISS + ".evil.example")
                 .claim("aud", java.util.List.of(CLIENT_ID))
                 .build();
 

--- a/src/test/java/com/mogak/spring/auth/AppleClaimsValidatorTest.java
+++ b/src/test/java/com/mogak/spring/auth/AppleClaimsValidatorTest.java
@@ -1,34 +1,54 @@
 package com.mogak.spring.auth;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AppleClaimsValidatorTest {
 
-    private static final String ISS = "iss";
+    private static final String ISS = "https://appleid.apple.com";
     private static final String CLIENT_ID = "aud";
-    private static final String NONCE = "nonce";
-    private static final String NONCE_KEY = "nonce";
 
     private final AppleClaimsValidator appleClaimsValidator = new AppleClaimsValidator(ISS, CLIENT_ID);
 
     @Test
     @DisplayName("올바른 Claims 이면 true 반환한다")
     void isValid() {
-        Map<String, Object> claimsMap = new HashMap<>();
-        claimsMap.put(NONCE_KEY, EncryptUtils.encrypt(NONCE));
-
-        Claims claims = Jwts.claims(claimsMap)
-                .setIssuer(ISS)
-                .setAudience(CLIENT_ID);
+        Jwt claims = Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .claim("iss", ISS)
+                .claim("aud", java.util.List.of(CLIENT_ID))
+                .claims(values -> values.putAll(Map.of("nonce", "nonce")))
+                .build();
 
         assertThat(appleClaimsValidator.isValid(claims)).isTrue();
+    }
+
+    @Test
+    @DisplayName("URL로 변환할 수 없는 issuer는 false를 반환한다")
+    void returnsFalseWhenIssuerCannotBeConvertedToUrl() {
+        Jwt claims = Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .claim("iss", "not-apple")
+                .claim("aud", java.util.List.of(CLIENT_ID))
+                .build();
+
+        assertThat(appleClaimsValidator.isValid(claims)).isFalse();
+    }
+
+    @Test
+    @DisplayName("audience가 client id를 포함하지 않으면 false를 반환한다")
+    void returnsFalseWhenAudienceDoesNotContainClientId() {
+        Jwt claims = Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .claim("iss", ISS)
+                .claim("aud", java.util.List.of("other-client"))
+                .build();
+
+        assertThat(appleClaimsValidator.isValid(claims)).isFalse();
     }
 }

--- a/src/test/java/com/mogak/spring/auth/AppleJwtParserTest.java
+++ b/src/test/java/com/mogak/spring/auth/AppleJwtParserTest.java
@@ -1,16 +1,25 @@
 package com.mogak.spring.auth;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import com.mogak.spring.global.ErrorCode;
+import com.mogak.spring.support.ErrorCodeAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 
 import java.security.*;
-import java.util.Date;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class AppleJwtParserTest {
@@ -19,20 +28,8 @@ public class AppleJwtParserTest {
     @Test
     @DisplayName("Apple identity token으로 헤더를 파싱한다")
     void parseHeaders() throws NoSuchAlgorithmException {
-        Date now = new Date();
-        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
-                .generateKeyPair();
-        PrivateKey privateKey = keyPair.getPrivate();
-
-        String identityToken = Jwts.builder()
-                .setHeaderParam("kid", "W2R4HXF3K")
-                .claim("id", "12345678")
-                .setIssuer("iss")
-                .setIssuedAt(now)
-                .setAudience("aud")
-                .setExpiration(new Date(now.getTime() + 1000 * 60 * 60 * 24))
-                .signWith(SignatureAlgorithm.RS256, privateKey)
-                .compact();
+        KeyPair keyPair = generateKeyPair();
+        String identityToken = createIdentityToken(keyPair, Instant.now().plusSeconds(60 * 60 * 24));
 
         Map<String, String> actual = appleJwtParser.parseHeaders(identityToken);
 
@@ -43,26 +40,14 @@ public class AppleJwtParserTest {
     @DisplayName("Apple identity token, PublicKey를 받아 사용자 정보가 포함된 Claims를 반환한다")
     void parsePublicKeyAndGetClaims() throws NoSuchAlgorithmException {
         String expected = "19281729";
-        Date now = new Date();
-        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
-                .generateKeyPair();
+        KeyPair keyPair = generateKeyPair();
         PublicKey publicKey = keyPair.getPublic();
-        PrivateKey privateKey = keyPair.getPrivate();
-        String identityToken = Jwts.builder()
-                .setHeaderParam("kid", "W2R4HXF3K")
-                .claim("id", "12345678")
-                .setIssuer("iss")
-                .setIssuedAt(now)
-                .setAudience("aud")
-                .setSubject(expected)
-                .setExpiration(new Date(now.getTime() + 1000 * 60 * 60 * 24))
-                .signWith(SignatureAlgorithm.RS256, privateKey)
-                .compact();
+        String identityToken = createIdentityToken(keyPair, expected, Instant.now().plusSeconds(60 * 60 * 24));
 
-        Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
+        Jwt claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
 
         assertAll(
-                () -> assertThat(claims).isNotEmpty(),
+                () -> assertThat(claims.getClaims()).isNotEmpty(),
                 () -> assertThat(claims.getSubject()).isEqualTo(expected)
         );
     }
@@ -71,21 +56,70 @@ public class AppleJwtParserTest {
     @DisplayName("만료된 Apple identity token을 받으면 Claims 획득 시에 예외를 반환한다")
     void parseExpiredTokenAndGetClaims() throws NoSuchAlgorithmException {
         String expected = "19281729";
-        Date now = new Date();
-        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
-                .generateKeyPair();
+        KeyPair keyPair = generateKeyPair();
         PublicKey publicKey = keyPair.getPublic();
-        PrivateKey privateKey = keyPair.getPrivate();
-        String identityToken = Jwts.builder()
-                .setHeaderParam("kid", "W2R4HXF3K")
+        String identityToken = createIdentityToken(keyPair, expected, Instant.now().minusSeconds(1));
+
+        Throwable throwable = catchThrowable(() -> appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.EXPIRE_APPLE_ID_TOKEN);
+    }
+
+    @Test
+    @DisplayName("서명이 다른 Apple identity token은 INVALID_APPLE_ID_TOKEN 예외를 반환한다")
+    void parseInvalidSignatureTokenAndGetClaims() throws NoSuchAlgorithmException {
+        KeyPair signingKeyPair = generateKeyPair();
+        KeyPair verificationKeyPair = generateKeyPair();
+        String identityToken = createIdentityToken(signingKeyPair, Instant.now().plusSeconds(60 * 60 * 24));
+
+        Throwable throwable = catchThrowable(() -> appleJwtParser.parsePublicKeyAndGetClaims(identityToken, verificationKeyPair.getPublic()));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_APPLE_ID_TOKEN);
+    }
+
+    @Test
+    @DisplayName("RSA public key가 아니면 WRONG_APPLE_PUBLIC_KEY 예외를 반환한다")
+    void parseWithNonRsaPublicKey() throws NoSuchAlgorithmException {
+        KeyPair rsaKeyPair = generateKeyPair();
+        KeyPair ecKeyPair = KeyPairGenerator.getInstance("EC")
+                .generateKeyPair();
+        String identityToken = createIdentityToken(rsaKeyPair, Instant.now().plusSeconds(60 * 60 * 24));
+
+        Throwable throwable = catchThrowable(() -> appleJwtParser.parsePublicKeyAndGetClaims(identityToken, ecKeyPair.getPublic()));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.WRONG_APPLE_PUBLIC_KEY);
+    }
+
+    private KeyPair generateKeyPair() throws NoSuchAlgorithmException {
+        return KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+    }
+
+    private String createIdentityToken(KeyPair keyPair, Instant expiresAt) {
+        return createIdentityToken(keyPair, "19281729", expiresAt);
+    }
+
+    private String createIdentityToken(KeyPair keyPair, String subject, Instant expiresAt) {
+        Instant now = Instant.now();
+        Instant issuedAt = expiresAt.isBefore(now) ? expiresAt.minusSeconds(60 * 60) : now;
+        JwsHeader jwsHeader = JwsHeader.with(SignatureAlgorithm.RS256)
+                .keyId("W2R4HXF3K")
+                .build();
+        JwtClaimsSet claimsSet = JwtClaimsSet.builder()
                 .claim("id", "12345678")
-                .setIssuer("iss")
-                .setIssuedAt(now)
-                .setAudience("aud")
-                .setSubject(expected)
-                .setExpiration(new Date(now.getTime() - 1L))
-                .signWith(SignatureAlgorithm.RS256, privateKey)
-                .compact();
+                .issuer("iss")
+                .issuedAt(issuedAt)
+                .audience(List.of("aud"))
+                .subject(subject)
+                .expiresAt(expiresAt)
+                .build();
+
+        return NimbusJwtEncoder.withKeyPair((RSAPublicKey) keyPair.getPublic(), (RSAPrivateKey) keyPair.getPrivate())
+                .algorithm(SignatureAlgorithm.RS256)
+                .jwkPostProcessor(jwk -> jwk.keyID("W2R4HXF3K"))
+                .build()
+                .encode(JwtEncoderParameters.from(jwsHeader, claimsSet))
+                .getTokenValue();
     }
 
 }

--- a/src/test/java/com/mogak/spring/auth/AppleJwtParserTest.java
+++ b/src/test/java/com/mogak/spring/auth/AppleJwtParserTest.java
@@ -58,11 +58,24 @@ public class AppleJwtParserTest {
         String expected = "19281729";
         KeyPair keyPair = generateKeyPair();
         PublicKey publicKey = keyPair.getPublic();
-        String identityToken = createIdentityToken(keyPair, expected, Instant.now().minusSeconds(1));
+        String identityToken = createIdentityToken(keyPair, expected, Instant.now().minusSeconds(60));
 
         Throwable throwable = catchThrowable(() -> appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey));
 
         ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.EXPIRE_APPLE_ID_TOKEN);
+    }
+
+    @Test
+    @DisplayName("30초 이내 clock skew가 있는 Apple identity token은 허용한다")
+    void parseTokenWithinClockSkew() throws NoSuchAlgorithmException {
+        String expected = "19281729";
+        KeyPair keyPair = generateKeyPair();
+        PublicKey publicKey = keyPair.getPublic();
+        String identityToken = createIdentityToken(keyPair, expected, Instant.now().minusSeconds(10));
+
+        Jwt claims = appleJwtParser.parsePublicKeyAndGetClaims(identityToken, publicKey);
+
+        assertThat(claims.getSubject()).isEqualTo(expected);
     }
 
     @Test

--- a/src/test/java/com/mogak/spring/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/mogak/spring/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,116 @@
+package com.mogak.spring.jwt;
+
+import com.mogak.spring.global.ErrorCode;
+import com.mogak.spring.support.ErrorCodeAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+class JwtTokenProviderTest {
+
+    private static final String SECRET = Base64.getEncoder()
+            .encodeToString("mogak-test-jwt-secret-for-hs256!".getBytes(StandardCharsets.UTF_8));
+    private static final String OTHER_SECRET = Base64.getEncoder()
+            .encodeToString("mogak-other-jwt-secret-for-hs256".getBytes(StandardCharsets.UTF_8));
+
+    @Test
+    @DisplayName("access token은 id와 email claim을 담아 발급한다")
+    void createAccessTokenContainsIdAndEmailClaims() {
+        JwtTokenProvider jwtTokenProvider = createProvider(SECRET, 7_200_000L, 2_678_400_000L);
+
+        String token = jwtTokenProvider.createAccessToken(1L, "user@test.com");
+        Jwt parsed = jwtTokenProvider.parseToken(token);
+
+        assertThat(((Number) parsed.getClaim("id")).longValue()).isEqualTo(1L);
+        assertThat(parsed.getClaimAsString("email")).isEqualTo("user@test.com");
+        assertThat(parsed.getSubject()).isEqualTo("user@test.com");
+    }
+
+    @Test
+    @DisplayName("refresh token의 subject에서 email을 추출한다")
+    void getEmailByRefresh() {
+        JwtTokenProvider jwtTokenProvider = createProvider(SECRET, 7_200_000L, 2_678_400_000L);
+        String refreshToken = jwtTokenProvider.createRefreshToken("user@test.com");
+
+        assertThat(jwtTokenProvider.getEmailByRefresh(refreshToken)).isEqualTo("user@test.com");
+    }
+
+    @Test
+    @DisplayName("refresh token 만료가 3일 이내이면 refresh token을 회전한다")
+    void refreshIssuesRefreshableTokenWhenWithinRefreshableWindow() {
+        JwtTokenProvider jwtTokenProvider = createProvider(SECRET, 7_200_000L, 1_000L);
+        String refreshToken = jwtTokenProvider.createRefreshToken("user@test.com");
+
+        JwtTokens jwtTokens = jwtTokenProvider.refresh(refreshToken, 1L, "user@test.com");
+
+        assertThat(jwtTokens.getAccessToken()).isNotBlank();
+        assertThat(jwtTokens.getRefreshToken()).isNotBlank();
+        assertThat(jwtTokenProvider.getEmailByRefresh(jwtTokens.getRefreshToken())).isEqualTo("user@test.com");
+    }
+
+    @Test
+    @DisplayName("만료된 access token은 EXPIRE_TOKEN으로 거부한다")
+    void validateExpiredAccessToken() {
+        JwtTokenProvider jwtTokenProvider = createProvider(SECRET, 7_200_000L, 2_678_400_000L);
+        Instant now = Instant.now();
+        String token = new JwtTokenCodec(SECRET).encode(JwtClaimsSet.builder()
+                .claim("id", 1L)
+                .claim("email", "user@test.com")
+                .subject("user@test.com")
+                .issuedAt(now.minusSeconds(120))
+                .expiresAt(now.minusSeconds(60))
+                .build());
+
+        Throwable throwable = catchThrowable(() -> jwtTokenProvider.validateAccessToken(token));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.EXPIRE_TOKEN);
+    }
+
+    @Test
+    @DisplayName("서명이 다른 access token은 WRONG_TOKEN으로 거부한다")
+    void validateAccessTokenWithInvalidSignature() {
+        JwtTokenProvider issuer = createProvider(SECRET, 7_200_000L, 2_678_400_000L);
+        JwtTokenProvider verifier = createProvider(OTHER_SECRET, 7_200_000L, 2_678_400_000L);
+        String token = issuer.createAccessToken(1L, "user@test.com");
+
+        Throwable throwable = catchThrowable(() -> verifier.validateAccessToken(token));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.WRONG_TOKEN);
+    }
+
+    @Test
+    @DisplayName("jwt.secret은 Base64 형식이어야 한다")
+    void rejectsNonBase64Secret() {
+        assertThatThrownBy(() -> new JwtTokenCodec("not-base64-secret"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Base64");
+    }
+
+    @Test
+    @DisplayName("jwt.secret은 HS256을 위해 32바이트 이상이어야 한다")
+    void rejectsShortSecret() {
+        String shortSecret = Base64.getEncoder()
+                .encodeToString("short-secret".getBytes(StandardCharsets.UTF_8));
+
+        assertThatThrownBy(() -> new JwtTokenCodec(shortSecret))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("32 bytes");
+    }
+
+    private JwtTokenProvider createProvider(String secret, long accessTokenValidTime, long refreshTokenValidTime) {
+        JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(null, new JwtTokenCodec(secret));
+        ReflectionTestUtils.setField(jwtTokenProvider, "accessTokenValidTime", accessTokenValidTime);
+        ReflectionTestUtils.setField(jwtTokenProvider, "refreshTokenValidTime", refreshTokenValidTime);
+        return jwtTokenProvider;
+    }
+}

--- a/src/test/java/com/mogak/spring/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/mogak/spring/jwt/JwtTokenProviderTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -74,6 +75,38 @@ class JwtTokenProviderTest {
         Throwable throwable = catchThrowable(() -> jwtTokenProvider.validateAccessToken(token));
 
         ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.EXPIRE_TOKEN);
+    }
+
+    @Test
+    @DisplayName("30초 이내 clock skew가 있는 access token은 허용한다")
+    void validateAccessTokenWithinClockSkew() {
+        JwtTokenProvider jwtTokenProvider = createProvider(SECRET, 7_200_000L, 2_678_400_000L);
+        Instant now = Instant.now();
+        String token = new JwtTokenCodec(SECRET).encode(JwtClaimsSet.builder()
+                .claim("id", 1L)
+                .claim("email", "user@test.com")
+                .subject("user@test.com")
+                .issuedAt(now.minusSeconds(120))
+                .expiresAt(now.minusSeconds(10))
+                .build());
+
+        assertThat(jwtTokenProvider.validateAccessToken(token)).isTrue();
+    }
+
+    @Test
+    @DisplayName("수동 만료 비교도 30초 이내 clock skew를 허용한다")
+    void isNotExpiredAtAllowsClockSkew() {
+        JwtTokenProvider jwtTokenProvider = createProvider(SECRET, 7_200_000L, 2_678_400_000L);
+        Instant now = Instant.now();
+        String token = new JwtTokenCodec(SECRET).encode(JwtClaimsSet.builder()
+                .claim("id", 1L)
+                .claim("email", "user@test.com")
+                .subject("user@test.com")
+                .issuedAt(now.minusSeconds(120))
+                .expiresAt(now.minusSeconds(10))
+                .build());
+
+        assertThat(jwtTokenProvider.isNotExpiredAt(token, Date.from(now))).isTrue();
     }
 
     @Test

--- a/src/test/java/com/mogak/spring/login/JwtTokenHandlerTest.java
+++ b/src/test/java/com/mogak/spring/login/JwtTokenHandlerTest.java
@@ -1,0 +1,48 @@
+package com.mogak.spring.login;
+
+import com.mogak.spring.jwt.JwtTokenCodec;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtTokenHandlerTest {
+
+    private static final String SECRET = Base64.getEncoder()
+            .encodeToString("mogak-test-jwt-secret-for-hs256!".getBytes(StandardCharsets.UTF_8));
+
+    private final JwtTokenHandler jwtTokenHandler = new JwtTokenHandler(new JwtTokenCodec(SECRET));
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    @DisplayName("레거시 JwtTokenHandler는 새 표준 id claim에서 userPk를 읽는다")
+    void getUserPkReadsIdClaim() {
+        String token = jwtTokenHandler.createJwtToken("10");
+
+        assertThat(jwtTokenHandler.getUserPk(token)).isEqualTo("10");
+    }
+
+    @Test
+    @DisplayName("AuthHandler는 Authorization Bearer 토큰에서 user id를 복원한다")
+    void authHandlerReadsUserIdFromBearerToken() {
+        String token = jwtTokenHandler.createJwtToken("10");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(JwtTokenHandler.AUTHORIZATION, "Bearer " + token);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        AuthHandler authHandler = new AuthHandler(jwtTokenHandler);
+
+        assertThat(authHandler.getUserId()).isEqualTo(10L);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -41,7 +41,7 @@ springdoc:
     - /**
 
 jwt:
-  secret: test-secret-key-for-jwt-token
+  secret: bW9nYWstdGVzdC1qd3Qtc2VjcmV0LWZvci1oczI1NiE=
   access-token-expiry: 7200000
   refresh-token-expiry: 2678400000
 


### PR DESCRIPTION
## 요약
- Apple identity token parsing을 JJWT에서 Spring Security OAuth2 JOSE/Nimbus 기반으로 전환
- 앱 내부 access/refresh token 발급·검증도 공통 JwtTokenCodec을 통해 Nimbus 기반으로 전환
- legacy io.jsonwebtoken:jjwt:0.9.1, 직접 javax.xml.bind:jaxb-api:2.3.1, 직접 Nimbus 9.30.1 pin을 제거
- JWT_SECRET_KEY는 Base64 인코딩된 32바이트 이상 HS256 key로 해석하도록 변경

## 주의사항
- 운영 환경의 JWT_SECRET_KEY는 이제 raw 문자열이 아니라 Base64 인코딩된 32바이트 이상 HMAC key여야 합니다.
- secret 형식 변경으로 기존 발급 token은 호환되지 않을 수 있으므로 배포 시 token 회전/재로그인 영향이 있습니다.

## 관련 이슈
#134