### PR TITLE
refactor(#144): 모다라트/모각/조각 및 개인 게시글 owner 권한 검증 추가

### DIFF
--- a/src/main/java/com/mogak/spring/repository/DailyJogakRepository.java
+++ b/src/main/java/com/mogak/spring/repository/DailyJogakRepository.java
@@ -33,8 +33,6 @@ public interface DailyJogakRepository extends JpaRepository<DailyJogak, Long> {
             "JOIN FETCH j.user " +
             "JOIN FETCH j.mogak " +
             "JOIN FETCH j.category " +
-            "JOIN FETCH dj.mogak " +
-            "JOIN FETCH dj.category " +
             "WHERE dj.id = :dailyJogakId")
     Optional<DailyJogak> findByIdWithJogakGraph(@Param("dailyJogakId") Long dailyJogakId);
 

--- a/src/main/java/com/mogak/spring/repository/DailyJogakRepository.java
+++ b/src/main/java/com/mogak/spring/repository/DailyJogakRepository.java
@@ -28,6 +28,16 @@ public interface DailyJogakRepository extends JpaRepository<DailyJogak, Long> {
                                      @Param(value = "today") LocalDateTime today,
                                      @Param(value = "tomorrow") LocalDateTime tomorrow);
 
+    @Query("SELECT dj FROM DailyJogak dj " +
+            "JOIN FETCH dj.jogak j " +
+            "JOIN FETCH j.user " +
+            "JOIN FETCH j.mogak " +
+            "JOIN FETCH j.category " +
+            "JOIN FETCH dj.mogak " +
+            "JOIN FETCH dj.category " +
+            "WHERE dj.id = :dailyJogakId")
+    Optional<DailyJogak> findByIdWithJogakGraph(@Param("dailyJogakId") Long dailyJogakId);
+
     void deleteAllByJogak(Jogak jogak);
 
     List<DailyJogak> findAllByJogak(Jogak jogak);

--- a/src/main/java/com/mogak/spring/service/JogakService.java
+++ b/src/main/java/com/mogak/spring/service/JogakService.java
@@ -9,22 +9,23 @@ import java.util.List;
 public interface JogakService {
 
     void createRoutineJogakToday();
-    JogakResponseDto.CreateJogakDto createJogak(JogakRequestDto.CreateJogakDto createJogakDto);
-    JogakResponseDto.CreateJogakDto updateJogak(Long jogakId, JogakRequestDto.UpdateJogakDto updateJogakDto);
+    JogakResponseDto.CreateJogakDto createJogak(Long userId, JogakRequestDto.CreateJogakDto createJogakDto);
+    JogakResponseDto.CreateJogakDto updateJogak(Long userId, Long jogakId, JogakRequestDto.UpdateJogakDto updateJogakDto);
     JogakResponseDto.GetOneTimeJogakListDto getDailyJogaks(Long userId, LocalDate day);
     JogakResponseDto.GetDailyJogakListDto getDayJogaks(Long userId, LocalDate day);
 //    void failRoutineJogakAtMidnight();
 //    void failJogakAtFour();
 
-    JogakResponseDto.JogakDailyJogakDto startJogak(Long jogakId);
+    JogakResponseDto.JogakDailyJogakDto startJogak(Long userId, Long jogakId);
 
-    JogakResponseDto.JogakDailyJogakDto successJogak(Long dailyJogakId);
+    JogakResponseDto.JogakDailyJogakDto successJogak(Long userId, Long dailyJogakId);
 
-    void deleteJogak(Long jogakId);
+    void deleteJogak(Long userId, Long jogakId);
+    void deleteJogakCascadeAfterParentAuthorization(Long jogakId);
 
     List<JogakResponseDto.GetRoutineJogakDto> getRoutineJogaks(Long userId, LocalDate startDay, LocalDate endDay);
 
-    JogakResponseDto.JogakDailyJogakDto failJogak(Long dailyJogakId);
+    JogakResponseDto.JogakDailyJogakDto failJogak(Long userId, Long dailyJogakId);
 
-    JogakResponseDto.DetailJogakDto getJogakDetail(Long jogakId);
+    JogakResponseDto.DetailJogakDto getJogakDetail(Long userId, Long jogakId);
 }

--- a/src/main/java/com/mogak/spring/service/JogakServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/JogakServiceImpl.java
@@ -10,6 +10,7 @@ import com.mogak.spring.domain.jogak.Period;
 import com.mogak.spring.domain.mogak.Mogak;
 import com.mogak.spring.domain.user.User;
 import com.mogak.spring.exception.BaseException;
+import com.mogak.spring.exception.AuthException;
 import com.mogak.spring.exception.JogakException;
 import com.mogak.spring.exception.MogakException;
 import com.mogak.spring.exception.UserException;
@@ -80,9 +81,11 @@ public class JogakServiceImpl implements JogakService {
 
     @Transactional
     @Override
-    public JogakResponseDto.CreateJogakDto createJogak(JogakRequestDto.CreateJogakDto createJogakDto) {
+    public JogakResponseDto.CreateJogakDto createJogak(Long userId, JogakRequestDto.CreateJogakDto createJogakDto) {
         Mogak mogak = mogakRepository.findById(createJogakDto.getMogakId())
                 .orElseThrow(() -> new MogakException(ErrorCode.NOT_EXIST_MOGAK));
+        validateMogakOwner(userId, mogak);
+
         // 조각 갯수 검증
         if (!validateJogakNum(mogak)) {
             throw new BaseException(ErrorCode.EXCEED_MAX_JOGAK);
@@ -138,9 +141,11 @@ public class JogakServiceImpl implements JogakService {
 
     @Transactional
     @Override
-    public JogakResponseDto.CreateJogakDto updateJogak(Long jogakId, JogakRequestDto.UpdateJogakDto updateJogakDto) {
+    public JogakResponseDto.CreateJogakDto updateJogak(Long userId, Long jogakId, JogakRequestDto.UpdateJogakDto updateJogakDto) {
         Jogak jogak = jogakRepository.findById(jogakId)
                 .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
+        validateJogakOwner(userId, jogak);
+
         validatePeriod(Optional.ofNullable(updateJogakDto.getIsRoutine()), Optional.ofNullable(updateJogakDto.getDays()));
         jogak.update(updateJogakDto.getTitle(), updateJogakDto.getIsRoutine(), updateJogakDto.getEndDate());
 
@@ -156,7 +161,7 @@ public class JogakServiceImpl implements JogakService {
             updateJogakPeriod(jogak, updateJogakDto.getDays());
         }
         if (updateJogakDto.getIsRoutine() != null && !updateJogakDto.getIsRoutine()) {
-            jogakPeriodRepository.deleteAllByJogakId(jogakId);
+            jogakPeriodRepository.deleteAllByJogakId(jogak.getId());
         }
 
         return JogakConverter.toCreateJogakResponseDto(jogak);
@@ -317,9 +322,11 @@ public class JogakServiceImpl implements JogakService {
 
     @Transactional
     @Override
-    public JogakResponseDto.JogakDailyJogakDto startJogak(Long jogakId) {
+    public JogakResponseDto.JogakDailyJogakDto startJogak(Long userId, Long jogakId) {
         Jogak jogak = jogakRepository.findById(jogakId)
                 .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
+        validateJogakOwner(userId, jogak);
+
         if (jogak.getIsRoutine() ||
                 dailyJogakRepository.findByCreatedAtBetweenAndId(
                         LocalDate.now().atStartOfDay(),
@@ -333,34 +340,36 @@ public class JogakServiceImpl implements JogakService {
 
     @Transactional
     @Override
-    public JogakResponseDto.JogakDailyJogakDto successJogak(Long dailyJogakId) {
-        DailyJogak dailyJogak = dailyJogakRepository.findById(dailyJogakId)
+    public JogakResponseDto.JogakDailyJogakDto successJogak(Long userId, Long dailyJogakId) {
+        DailyJogak dailyJogak = dailyJogakRepository.findByIdWithJogakGraph(dailyJogakId)
                 .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
-        Jogak jogak = jogakRepository.findByDailyJogak(dailyJogak)
-                .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
+        validateDailyJogakOwner(userId, dailyJogak);
+        Jogak jogak = dailyJogak.getJogak();
+
         if (dailyJogak.getIsAchievement()) {
             throw new BaseException(ErrorCode.ALREADY_END_JOGAK);
         }
 
         updateAchievement(true, jogak, dailyJogak);
 
-        return JogakConverter.toJogakDailyJogakDto(dailyJogak.getJogak(), dailyJogak);
+        return JogakConverter.toJogakDailyJogakDto(jogak, dailyJogak);
     }
 
     @Transactional
     @Override
-    public JogakResponseDto.JogakDailyJogakDto failJogak(Long dailyJogakId) {
-        DailyJogak dailyJogak = dailyJogakRepository.findById(dailyJogakId)
+    public JogakResponseDto.JogakDailyJogakDto failJogak(Long userId, Long dailyJogakId) {
+        DailyJogak dailyJogak = dailyJogakRepository.findByIdWithJogakGraph(dailyJogakId)
                 .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
-        Jogak jogak = jogakRepository.findByDailyJogak(dailyJogak)
-                .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
+        validateDailyJogakOwner(userId, dailyJogak);
+        Jogak jogak = dailyJogak.getJogak();
+
         if (!dailyJogak.getIsAchievement()) {
             throw new BaseException(ErrorCode.NOT_SUCCESS_DAILY_JOGAK);
         }
 
         updateAchievement(false, jogak, dailyJogak);
-        
-        return JogakConverter.toJogakDailyJogakDto(dailyJogak.getJogak(), dailyJogak);
+
+        return JogakConverter.toJogakDailyJogakDto(jogak, dailyJogak);
     }
 
     private void updateAchievement(boolean achievement, Jogak jogak, DailyJogak dailyJogak) {
@@ -376,10 +385,7 @@ public class JogakServiceImpl implements JogakService {
         jogak.decreaseAchievements();
     }
 
-    @Override
-    public JogakResponseDto.DetailJogakDto getJogakDetail(Long jogakId) {
-        Jogak jogak = jogakRepository.findById(jogakId)
-                .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
+    private JogakResponseDto.DetailJogakDto getJogakDetail(Jogak jogak) {
         Mogak mogak = mogakRepository.findByJogak(jogak)
                 .orElseThrow(() -> new BaseException(ErrorCode.NOT_EXIST_MOGAK));
 
@@ -392,14 +398,49 @@ public class JogakServiceImpl implements JogakService {
         return JogakConverter.toGetJogakDetailResponseDto(jogak, mogak.getColor());
     }
 
+    @Override
+    public JogakResponseDto.DetailJogakDto getJogakDetail(Long userId, Long jogakId) {
+        Jogak jogak = jogakRepository.findById(jogakId)
+                .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
+        validateJogakOwner(userId, jogak);
+        return getJogakDetail(jogak);
+    }
+
     @Transactional
     @Override
-    public void deleteJogak(Long jogakId) {
+    public void deleteJogakCascadeAfterParentAuthorization(Long jogakId) {
         Jogak jogak = jogakRepository.findById(jogakId)
                 .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
         jogakPeriodRepository.deleteAllByJogakId(jogakId);
         dailyJogakRepository.deleteAllByJogak(jogak);
         jogakRepository.deleteById(jogakId);
+    }
+
+    @Transactional
+    @Override
+    public void deleteJogak(Long userId, Long jogakId) {
+        Jogak jogak = jogakRepository.findById(jogakId)
+                .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
+        validateJogakOwner(userId, jogak);
+        deleteJogakCascadeAfterParentAuthorization(jogakId);
+    }
+
+    private void validateMogakOwner(Long userId, Mogak mogak) {
+        if (!Objects.equals(mogak.getUser().getId(), userId)) {
+            throw new AuthException(ErrorCode.INVALID_PERMISSION);
+        }
+    }
+
+    private void validateJogakOwner(Long userId, Jogak jogak) {
+        if (!Objects.equals(jogak.getUser().getId(), userId)) {
+            throw new AuthException(ErrorCode.INVALID_PERMISSION);
+        }
+    }
+
+    private void validateDailyJogakOwner(Long userId, DailyJogak dailyJogak) {
+        if (!Objects.equals(dailyJogak.getJogak().getUser().getId(), userId)) {
+            throw new AuthException(ErrorCode.INVALID_PERMISSION);
+        }
     }
 
     private int getTodayNum(LocalDateTime now) {

--- a/src/main/java/com/mogak/spring/service/ModaratService.java
+++ b/src/main/java/com/mogak/spring/service/ModaratService.java
@@ -10,8 +10,8 @@ import static com.mogak.spring.web.dto.modaratdto.ModaratResponseDto.ModaratDto;
 
 public interface ModaratService {
     Modarat create(Long userId, ModaratRequestDto.CreateModaratDto request);
-    void delete(Long modaratId);
-    Modarat update(Long modaratId, ModaratRequestDto.UpdateModaratDto request);
-    SingleDetailModaratDto getDetailModarat(Long modaratId);
+    void delete(Long userId, Long modaratId);
+    Modarat update(Long userId, Long modaratId, ModaratRequestDto.UpdateModaratDto request);
+    SingleDetailModaratDto getDetailModarat(Long userId, Long modaratId);
     List<ModaratDto> getModaratList(Long userId);
 }

--- a/src/main/java/com/mogak/spring/service/ModaratServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/ModaratServiceImpl.java
@@ -4,6 +4,7 @@ import com.mogak.spring.converter.ModaratConverter;
 import com.mogak.spring.domain.modarat.Modarat;
 import com.mogak.spring.domain.mogak.Mogak;
 import com.mogak.spring.domain.user.User;
+import com.mogak.spring.exception.AuthException;
 import com.mogak.spring.exception.BaseException;
 import com.mogak.spring.exception.UserException;
 import com.mogak.spring.global.ErrorCode;
@@ -19,10 +20,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 @Service
 public class ModaratServiceImpl implements ModaratService {
     private final UserRepository userRepository;
@@ -39,26 +41,25 @@ public class ModaratServiceImpl implements ModaratService {
 
     @Transactional
     @Override
-    public void delete(Long modaratId) {
-        Modarat modarat = modaratRepository.findById(modaratId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_EXIST_MODARAT));
+    public void delete(Long userId, Long modaratId) {
+        Modarat modarat = getOwnedModarat(modaratId, userId);
         List<Mogak> mogaks = mogakRepository.findAllByModaratId(modaratId);
-        mogaks.forEach(mogak -> mogakService.deleteMogak(mogak.getId()));
+        mogaks.forEach(mogak -> mogakService.deleteMogakCascadeAfterParentAuthorization(mogak.getId()));
         modaratRepository.delete(modarat);
     }
 
     @Transactional
     @Override
-    public Modarat update(Long modaratId, ModaratRequestDto.UpdateModaratDto request) {
-        Modarat modarat = modaratRepository.findById(modaratId)
-                .orElseThrow(()  -> new BaseException(ErrorCode.NOT_EXIST_MODARAT));
+    public Modarat update(Long userId, Long modaratId, ModaratRequestDto.UpdateModaratDto request) {
+        Modarat modarat = getOwnedModarat(modaratId, userId);
         modarat.update(request.getTitle(), request.getColor());
         return modarat;
     }
 
     @Override
-    public SingleDetailModaratDto getDetailModarat(Long modaratId) {
-        List<GetMogakInModaratDto> mogakDtoList = modaratRepository.findMogakDtoListByModaratId(modaratId).orElse(null);
+    public SingleDetailModaratDto getDetailModarat(Long userId, Long modaratId) {
+        Modarat modarat = getOwnedModarat(modaratId, userId);
+        List<GetMogakInModaratDto> mogakDtoList = modaratRepository.findMogakDtoListByModaratId(modarat.getId()).orElse(List.of());
         SingleDetailModaratDto modaratDto = modaratRepository.findOneDetailModarat(modaratId);
         modaratDto.updateMogakList(mogakDtoList);
         return modaratDto;
@@ -70,5 +71,14 @@ public class ModaratServiceImpl implements ModaratService {
         return modaratRepository.findModaratsByUserId(userId).stream()
                 .map(ModaratConverter::toModaratDto)
                 .collect(Collectors.toList());
+    }
+
+    private Modarat getOwnedModarat(Long modaratId, Long userId) {
+        Modarat modarat = modaratRepository.findById(modaratId)
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_EXIST_MODARAT));
+        if (!Objects.equals(modarat.getUser().getId(), userId)) {
+            throw new AuthException(ErrorCode.INVALID_PERMISSION);
+        }
+        return modarat;
     }
 }

--- a/src/main/java/com/mogak/spring/service/MogakService.java
+++ b/src/main/java/com/mogak/spring/service/MogakService.java
@@ -10,9 +10,10 @@ import java.util.List;
 public interface MogakService {
     MogakResponseDto.GetMogakDto create(Long userId, MogakRequestDto.CreateDto createDto);
 //    MogakResponseDto.UpdateStateDto achieveMogak(Long id);
-    MogakResponseDto.GetMogakDto updateMogak(MogakRequestDto.UpdateDto request);
+    MogakResponseDto.GetMogakDto updateMogak(Long userId, MogakRequestDto.UpdateDto request);
     MogakResponseDto.GetMogakListDto getMogakDtoList(Long userId, Long modaratId);
-    void deleteMogak(Long mogakId);
+    void deleteMogak(Long userId, Long mogakId);
+    void deleteMogakCascadeAfterParentAuthorization(Long mogakId);
 
     List<JogakResponseDto.GetJogakDto> getJogaks(Long userId, Long mogakId, LocalDate day);
 //    List<Mogak> getOngoingTodayMogakList(int name);

--- a/src/main/java/com/mogak/spring/service/MogakServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/MogakServiceImpl.java
@@ -8,6 +8,7 @@ import com.mogak.spring.domain.modarat.Modarat;
 import com.mogak.spring.domain.mogak.Mogak;
 import com.mogak.spring.domain.mogak.MogakCategory;
 import com.mogak.spring.domain.user.User;
+import com.mogak.spring.exception.AuthException;
 import com.mogak.spring.exception.BaseException;
 import com.mogak.spring.exception.MogakException;
 import com.mogak.spring.exception.UserException;
@@ -48,8 +49,7 @@ public class MogakServiceImpl implements MogakService {
     public MogakResponseDto.GetMogakDto create(Long userId, MogakRequestDto.CreateDto request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
-        Modarat modarat = modaratRepository.findById(request.getModaratId())
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_EXIST_MODARAT));
+        Modarat modarat = getOwnedModarat(request.getModaratId(), userId);
         if (!validateMogakNum(modarat)) {
             throw new BaseException(ErrorCode.EXCEED_MAX_MOGAK);
         }
@@ -131,9 +131,8 @@ public class MogakServiceImpl implements MogakService {
      * */
     @Transactional
     @Override
-    public MogakResponseDto.GetMogakDto updateMogak(MogakRequestDto.UpdateDto request) {
-        Mogak mogak = mogakRepository.findById(request.getMogakId())
-                .orElseThrow(() -> new MogakException(ErrorCode.NOT_EXIST_MOGAK));
+    public MogakResponseDto.GetMogakDto updateMogak(Long userId, MogakRequestDto.UpdateDto request) {
+        Mogak mogak = getOwnedMogak(request.getMogakId(), userId);
         Optional<String> categoryOptional = Optional.ofNullable(request.getBigCategory());
         categoryOptional.ifPresent(categoryValue -> {
             MogakCategory category = categoryRepository.findMogakCategoryByName(categoryValue)
@@ -154,7 +153,8 @@ public class MogakServiceImpl implements MogakService {
     public MogakResponseDto.GetMogakListDto getMogakDtoList(Long userId, Long modaratId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
-        return MogakConverter.toGetMogakListDto(mogakRepository.findAllByModaratId(modaratId));
+        Modarat modarat = getOwnedModarat(modaratId, userId);
+        return MogakConverter.toGetMogakListDto(mogakRepository.findAllByModaratId(modarat.getId()));
     }
 
     /**
@@ -204,11 +204,18 @@ public class MogakServiceImpl implements MogakService {
      * */
     @Transactional
     @Override
-    public void deleteMogak(Long mogakId) {
+    public void deleteMogak(Long userId, Long mogakId) {
+        Mogak mogak = getOwnedMogak(mogakId, userId);
+        deleteMogakCascadeAfterParentAuthorization(mogak.getId());
+    }
+
+    @Transactional
+    @Override
+    public void deleteMogakCascadeAfterParentAuthorization(Long mogakId) {
         Mogak mogak = mogakRepository.findById(mogakId)
                 .orElseThrow(() -> new MogakException(ErrorCode.NOT_EXIST_MOGAK));
         List<Jogak> jogaks = jogakRepository.findAllByMogak(mogak);
-        jogaks.forEach(jogak -> jogakService.deleteJogak(jogak.getId()));
+        jogaks.forEach(jogak -> jogakService.deleteJogakCascadeAfterParentAuthorization(jogak.getId()));
         dailyJogakRepository.flush();
         jogakRepository.flush();
 
@@ -231,8 +238,7 @@ public class MogakServiceImpl implements MogakService {
     public List<JogakResponseDto.GetJogakDto> getJogaks(Long userId, Long mogakId, LocalDate day) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
-        Mogak mogak = mogakRepository.findById(mogakId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_EXIST_MOGAK));
+        Mogak mogak = getOwnedMogak(mogakId, userId);
         List<DailyJogak> dailyJogak = dailyJogakRepository.findDailyJogaks(user, day.atStartOfDay(), day.atStartOfDay().plusDays(1));
         return mogak.getJogaks().stream()
                 .filter(jogak -> jogak.getEndAt() == null || jogak.getEndAt().isAfter(day.minusDays(1)))
@@ -243,5 +249,23 @@ public class MogakServiceImpl implements MogakService {
     private static Boolean findCorrespondingDailyJogak(Jogak jogak, List<DailyJogak> dailyJogaks) {
         return dailyJogaks.stream()
                 .anyMatch(dailyJogak -> dailyJogak.getJogak().equals(jogak));
+    }
+
+    private Modarat getOwnedModarat(Long modaratId, Long userId) {
+        Modarat modarat = modaratRepository.findById(modaratId)
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_EXIST_MODARAT));
+        if (!modarat.getUser().getId().equals(userId)) {
+            throw new AuthException(ErrorCode.INVALID_PERMISSION);
+        }
+        return modarat;
+    }
+
+    private Mogak getOwnedMogak(Long mogakId, Long userId) {
+        Mogak mogak = mogakRepository.findById(mogakId)
+                .orElseThrow(() -> new MogakException(ErrorCode.NOT_EXIST_MOGAK));
+        if (!mogak.getUser().getId().equals(userId)) {
+            throw new AuthException(ErrorCode.INVALID_PERMISSION);
+        }
+        return mogak;
     }
 }

--- a/src/main/java/com/mogak/spring/service/PostService.java
+++ b/src/main/java/com/mogak/spring/service/PostService.java
@@ -5,6 +5,7 @@ import com.mogak.spring.domain.post.PostImg;
 import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
 import com.mogak.spring.web.dto.postdto.PostRequestDto;
 import org.springframework.data.domain.Slice;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -12,11 +13,12 @@ import static com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkPostDto;
 
 public interface PostService {
 
+    void validateCreateAccess(Long userId, PostRequestDto.CreatePostDto request, List<MultipartFile> multipartFile, Long mogakId);
     Post create(Long userId, PostRequestDto.CreatePostDto request, List<PostImgRequestDto.CreatePostImgDto> postImgDtoList, Long mogakId);
-    Slice<Post> getAllPosts(int page, Long mogakId, int size);
-    Post findById(Long postId);
-    Post update(Long postId, PostRequestDto.UpdatePostDto request);
-    void delete(Long postId);
+    Slice<Post> getAllPosts(Long userId, int page, Long mogakId, int size);
+    Post findById(Long userId, Long postId);
+    Post update(Long userId, Long postId, PostRequestDto.UpdatePostDto request);
+    void delete(Long userId, Long postId);
     List<NetworkPostDto> getPacemakerPosts(Long userId, int cursor, int size);
     Slice<Post> getNetworkPosts(Long userId, int page, int size, String sort, String address);
     List<String> findImgUrlByPost(Long postId);

--- a/src/main/java/com/mogak/spring/service/PostServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/PostServiceImpl.java
@@ -206,13 +206,19 @@ public class PostServiceImpl implements PostService {
     }
 
     private void validateContents(PostRequestDto.CreatePostDto request) {
-        if (request == null || request.getContents() == null || request.getContents().length() > 350) {
+        if (request == null || request.getContents() == null) {
+            throw new PostException(ErrorCode.INVALID_PARAMETER_ERROR);
+        }
+        if (request.getContents().length() > 350) {
             throw new PostException(ErrorCode.EXCEED_MAX_NUM_POST);
         }
     }
 
     private void validateContents(PostRequestDto.UpdatePostDto request) {
-        if (request == null || request.contents == null || request.contents.length() > 350) {
+        if (request == null || request.contents == null) {
+            throw new PostException(ErrorCode.INVALID_PARAMETER_ERROR);
+        }
+        if (request.contents.length() > 350) {
             throw new PostException(ErrorCode.EXCEED_MAX_NUM_POST);
         }
     }

--- a/src/main/java/com/mogak/spring/service/PostServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/PostServiceImpl.java
@@ -8,6 +8,7 @@ import com.mogak.spring.domain.mogak.Mogak;
 import com.mogak.spring.domain.post.Post;
 import com.mogak.spring.domain.post.PostImg;
 import com.mogak.spring.domain.user.User;
+import com.mogak.spring.exception.AuthException;
 import com.mogak.spring.exception.MogakException;
 import com.mogak.spring.exception.PostException;
 import com.mogak.spring.exception.UserException;
@@ -22,9 +23,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -42,19 +45,23 @@ public class PostServiceImpl implements PostService {
      * TODO 회고록 - user id로 조회되도록 수정
      */
 
+    @Override
+    public void validateCreateAccess(Long userId, PostRequestDto.CreatePostDto request, List<MultipartFile> multipartFile, Long mogakId) {
+        Mogak mogak = getMogak(mogakId);
+        validateOwner(mogak.getUser().getId(), userId);
+        validateContents(request);
+        validateSourceImages(multipartFile);
+    }
+
     //회고록 & 회고록 이미지 생성 => 리팩토링 필요
     @Transactional
     @Override
     public Post create(Long userId, PostRequestDto.CreatePostDto request, List<PostImgRequestDto.CreatePostImgDto> postImgDtoList, Long mogakId) {
-        Mogak mogak = mogakRepository.findById(mogakId).orElseThrow(() -> new MogakException(ErrorCode.NOT_EXIST_MOGAK));
+        Mogak mogak = getOwnedMogak(userId, mogakId);
         User user = userRepository.findById(userId).orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
-        if (request.getContents().length() > 350) {
-            throw new PostException(ErrorCode.EXCEED_MAX_NUM_POST);
-        }
+        validateContents(request);
+        validateCreatedImages(postImgDtoList);
         Post post = PostConverter.toPost(request, user, mogak);
-        if (postImgDtoList.isEmpty()) {
-            throw new PostException(ErrorCode.NOT_HAVE_IMAGE);
-        }
         for (PostImgRequestDto.CreatePostImgDto postImgDto : postImgDtoList) {
             PostImg postImg = PostImgConverter.toPostImg(postImgDto, post);
             //썸네일이미지인지 체크 필요
@@ -70,41 +77,35 @@ public class PostServiceImpl implements PostService {
 
     //회고록 조회 - 무한 스크롤
     @Override
-    public Slice<Post> getAllPosts(int page, Long mogakId, int size) {
-        Mogak mogak = mogakRepository.findById(mogakId).orElseThrow(() ->
-                new MogakException(ErrorCode.NOT_EXIST_MOGAK)
-        );
-        Pageable pageable=PageRequest.of(page, size);
+    public Slice<Post> getAllPosts(Long userId, int page, Long mogakId, int size) {
+        getOwnedMogak(userId, mogakId);
+        Pageable pageable = PageRequest.of(page, size);
 
-        Slice<Post> posts = postRepository.findAllPosts( mogakId, pageable);
-        return posts;
+        return postRepository.findAllPosts(mogakId, pageable);
     }
 
     //회고록 상세 조회 + 댓글, 이미지 같이 보이게
     @Override
-    public Post findById(Long postId) {
-        return postRepository.findById(postId).orElseThrow(() -> new PostException(ErrorCode.NOT_EXIST_POST));
+    public Post findById(Long userId, Long postId) {
+        return getOwnedPost(userId, postId);
     }
 
 
     //회고록 수정
     @Transactional
     @Override
-    public Post update(Long postId, PostRequestDto.UpdatePostDto request) {
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new PostException(ErrorCode.NOT_EXIST_POST));
-        if (request.getContents().length() > 350) {
-            throw new PostException(ErrorCode.EXCEED_MAX_NUM_POST);
-        }
-        post.updatePost(request.getContents());
+    public Post update(Long userId, Long postId, PostRequestDto.UpdatePostDto request) {
+        Post post = getOwnedPost(userId, postId);
+        validateContents(request);
+        post.updatePost(request.contents);
         return post;
     }
 
     //회고록 삭제
     @Transactional
     @Override
-    public void delete(Long postId) {
-        Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(ErrorCode.NOT_EXIST_POST));
+    public void delete(Long userId, Long postId) {
+        Post post = getOwnedPost(userId, postId);
         //이미지 삭제
         postImgRepository.deleteAllByPost(post);
         //댓글 삭제
@@ -185,6 +186,53 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<PostImg> findAllImgByPost(Post post){
         return postImgRepository.findAllByPost(post);
+    }
+
+    private Mogak getMogak(Long mogakId) {
+        return mogakRepository.findById(mogakId).orElseThrow(() -> new MogakException(ErrorCode.NOT_EXIST_MOGAK));
+    }
+
+    private Mogak getOwnedMogak(Long userId, Long mogakId) {
+        Mogak mogak = getMogak(mogakId);
+        validateOwner(mogak.getUser().getId(), userId);
+        return mogak;
+    }
+
+    private Post getOwnedPost(Long userId, Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(ErrorCode.NOT_EXIST_POST));
+        validateOwner(post.getUser().getId(), userId);
+        return post;
+    }
+
+    private void validateContents(PostRequestDto.CreatePostDto request) {
+        if (request == null || request.getContents() == null || request.getContents().length() > 350) {
+            throw new PostException(ErrorCode.EXCEED_MAX_NUM_POST);
+        }
+    }
+
+    private void validateContents(PostRequestDto.UpdatePostDto request) {
+        if (request == null || request.contents == null || request.contents.length() > 350) {
+            throw new PostException(ErrorCode.EXCEED_MAX_NUM_POST);
+        }
+    }
+
+    private void validateSourceImages(List<MultipartFile> multipartFile) {
+        if (multipartFile == null || multipartFile.stream().allMatch(MultipartFile::isEmpty)) {
+            throw new PostException(ErrorCode.NOT_HAVE_IMAGE);
+        }
+    }
+
+    private void validateCreatedImages(List<PostImgRequestDto.CreatePostImgDto> postImgDtoList) {
+        if (postImgDtoList == null || postImgDtoList.isEmpty()) {
+            throw new PostException(ErrorCode.NOT_HAVE_IMAGE);
+        }
+    }
+
+    private void validateOwner(Long ownerUserId, Long userId) {
+        if (!Objects.equals(ownerUserId, userId)) {
+            throw new AuthException(ErrorCode.INVALID_PERMISSION);
+        }
     }
 
 }

--- a/src/main/java/com/mogak/spring/web/controller/JogakController.java
+++ b/src/main/java/com/mogak/spring/web/controller/JogakController.java
@@ -44,8 +44,9 @@ public class JogakController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @PostMapping("")
-    public ResponseEntity<BaseResponse<JogakResponseDto.CreateJogakDto>> create(@Valid @RequestBody JogakRequestDto.CreateJogakDto createJogakDto) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponse<>(jogakService.createJogak(createJogakDto)));
+    public ResponseEntity<BaseResponse<JogakResponseDto.CreateJogakDto>> create(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                                                 @Valid @RequestBody JogakRequestDto.CreateJogakDto createJogakDto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponse<>(jogakService.createJogak(authenticatedUser.getUserId(), createJogakDto)));
     }
 
     @Operation(summary = "단일 조각 조회", description = "조각 ID를 통해 조각 정보를 조회하는 API",
@@ -56,8 +57,9 @@ public class JogakController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @GetMapping("/{jogakId}/detail")
-    public ResponseEntity<BaseResponse<JogakResponseDto.DetailJogakDto>> getJogakDetail(@PathVariable Long jogakId) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.getJogakDetail(jogakId)));
+    public ResponseEntity<BaseResponse<JogakResponseDto.DetailJogakDto>> getJogakDetail(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                                                         @PathVariable Long jogakId) {
+        return ResponseEntity.ok(new BaseResponse<>(jogakService.getJogakDetail(authenticatedUser.getUserId(), jogakId)));
     }
 
 
@@ -116,8 +118,9 @@ public class JogakController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @PostMapping("{jogakId}/start")
-    public ResponseEntity<BaseResponse<JogakResponseDto.JogakDailyJogakDto>> startJogak(@PathVariable Long jogakId) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.startJogak(jogakId)));
+    public ResponseEntity<BaseResponse<JogakResponseDto.JogakDailyJogakDto>> startJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                                                        @PathVariable Long jogakId) {
+        return ResponseEntity.ok(new BaseResponse<>(jogakService.startJogak(authenticatedUser.getUserId(), jogakId)));
     }
 
     @Operation(summary = "조각 성공", description = "오늘의 조각으로 등록된 조각을 성공시킵니다",
@@ -133,8 +136,9 @@ public class JogakController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @PutMapping("{dailyJogakId}/success")
-    public ResponseEntity<BaseResponse<JogakResponseDto.JogakDailyJogakDto>> successJogak(@PathVariable Long dailyJogakId) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.successJogak(dailyJogakId)));
+    public ResponseEntity<BaseResponse<JogakResponseDto.JogakDailyJogakDto>> successJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                                                           @PathVariable Long dailyJogakId) {
+        return ResponseEntity.ok(new BaseResponse<>(jogakService.successJogak(authenticatedUser.getUserId(), dailyJogakId)));
     }
 
     @Operation(summary = "조각 실패", description = "성공한 조각을 취소합니다",
@@ -150,8 +154,9 @@ public class JogakController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @PutMapping("{dailyJogakId}/fail")
-    public ResponseEntity<BaseResponse<JogakResponseDto.JogakDailyJogakDto>> failJogak(@PathVariable Long dailyJogakId) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.failJogak(dailyJogakId)));
+    public ResponseEntity<BaseResponse<JogakResponseDto.JogakDailyJogakDto>> failJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                                                        @PathVariable Long dailyJogakId) {
+        return ResponseEntity.ok(new BaseResponse<>(jogakService.failJogak(authenticatedUser.getUserId(), dailyJogakId)));
     }
 
     @Operation(summary = "조각 수정", description = "입력값을 이용해 조각을 수정합니다",
@@ -164,9 +169,10 @@ public class JogakController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @PutMapping("/{jogakId}")
-    public ResponseEntity<BaseResponse<JogakResponseDto.CreateJogakDto>> updateJogak(@PathVariable Long jogakId,
+    public ResponseEntity<BaseResponse<JogakResponseDto.CreateJogakDto>> updateJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                               @PathVariable Long jogakId,
                                                                @Valid @RequestBody JogakRequestDto.UpdateJogakDto updateJogakDto) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.updateJogak(jogakId, updateJogakDto)));
+        return ResponseEntity.ok(new BaseResponse<>(jogakService.updateJogak(authenticatedUser.getUserId(), jogakId, updateJogakDto)));
     }
 
     @Operation(summary = "조각 삭제", description = "조각을 삭제합니다",
@@ -178,8 +184,9 @@ public class JogakController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @DeleteMapping("/{jogakId}")
-    public ResponseEntity<BaseResponse<ErrorCode>> deleteJogak(@PathVariable Long jogakId) {
-        jogakService.deleteJogak(jogakId);
+    public ResponseEntity<BaseResponse<ErrorCode>> deleteJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                               @PathVariable Long jogakId) {
+        jogakService.deleteJogak(authenticatedUser.getUserId(), jogakId);
         return ResponseEntity.ok(new BaseResponse<>(ErrorCode.SUCCESS));
     }
 

--- a/src/main/java/com/mogak/spring/web/controller/ModaratController.java
+++ b/src/main/java/com/mogak/spring/web/controller/ModaratController.java
@@ -5,6 +5,7 @@ import com.mogak.spring.domain.modarat.Modarat;
 import com.mogak.spring.jwt.AuthenticatedUser;
 import com.mogak.spring.exception.ErrorResponse;
 import com.mogak.spring.global.BaseResponse;
+import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.repository.query.SingleDetailModaratDto;
 import com.mogak.spring.service.ModaratService;
 import com.mogak.spring.web.dto.modaratdto.ModaratRequestDto;
@@ -54,9 +55,10 @@ public class ModaratController {
                     @ApiResponse(responseCode = "200", description = "모각 삭제 성공")
             })
     @DeleteMapping("{modaratId}")
-    public ResponseEntity<BaseResponse<Void>> deleteModarat(@PathVariable Long modaratId) {
-        modaratService.delete(modaratId);
-        return ResponseEntity.status(HttpStatus.OK).build();
+    public ResponseEntity<BaseResponse<ErrorCode>> deleteModarat(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                                 @PathVariable Long modaratId) {
+        modaratService.delete(authenticatedUser.getUserId(), modaratId);
+        return ResponseEntity.ok(new BaseResponse<>(ErrorCode.SUCCESS));
     }
 
     @Operation(summary = "모다라트 수정", description = "입력값을 이용해 모다라트를 수정합니다",
@@ -65,9 +67,10 @@ public class ModaratController {
                     @ApiResponse(responseCode = "201", description = "모각 수정 성공"),
             })
     @PutMapping("/{modaratId}")
-    public ResponseEntity<BaseResponse<ModaratDto>> updateModarat(@PathVariable Long modaratId,
+    public ResponseEntity<BaseResponse<ModaratDto>> updateModarat(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                                  @PathVariable Long modaratId,
                                                                   @Valid @RequestBody ModaratRequestDto.UpdateModaratDto request) {
-        Modarat modarat = modaratService.update(modaratId, request);
+        Modarat modarat = modaratService.update(authenticatedUser.getUserId(), modaratId, request);
         return ResponseEntity.status(HttpStatus.OK).body(new BaseResponse<>(ModaratConverter.toModaratDto(modarat)));
     }
 
@@ -79,8 +82,9 @@ public class ModaratController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @GetMapping("/{modaratId}")
-    public ResponseEntity<BaseResponse<SingleDetailModaratDto>> getSingleDetailModarat(@PathVariable Long modaratId) {
-        return ResponseEntity.status(HttpStatus.OK).body(new BaseResponse<>(modaratService.getDetailModarat(modaratId)));
+    public ResponseEntity<BaseResponse<SingleDetailModaratDto>> getSingleDetailModarat(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                                                       @PathVariable Long modaratId) {
+        return ResponseEntity.status(HttpStatus.OK).body(new BaseResponse<>(modaratService.getDetailModarat(authenticatedUser.getUserId(), modaratId)));
     }
 
     @Operation(summary = "모다라트 리스트 조회", description = "사용자의 모다라트 리스트를 조회합니다",

--- a/src/main/java/com/mogak/spring/web/controller/ModaratController.java
+++ b/src/main/java/com/mogak/spring/web/controller/ModaratController.java
@@ -5,7 +5,6 @@ import com.mogak.spring.domain.modarat.Modarat;
 import com.mogak.spring.jwt.AuthenticatedUser;
 import com.mogak.spring.exception.ErrorResponse;
 import com.mogak.spring.global.BaseResponse;
-import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.repository.query.SingleDetailModaratDto;
 import com.mogak.spring.service.ModaratService;
 import com.mogak.spring.web.dto.modaratdto.ModaratRequestDto;
@@ -52,19 +51,19 @@ public class ModaratController {
     @Operation(summary = "모다라트 삭제", description = "모다라트를 삭제합니다",
             security = @SecurityRequirement(name = "Bearer Authentication"),
             responses = {
-                    @ApiResponse(responseCode = "200", description = "모각 삭제 성공")
+                    @ApiResponse(responseCode = "200", description = "모다라트 삭제 성공")
             })
     @DeleteMapping("{modaratId}")
-    public ResponseEntity<BaseResponse<ErrorCode>> deleteModarat(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
-                                                                 @PathVariable Long modaratId) {
+    public ResponseEntity<Void> deleteModarat(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                              @PathVariable Long modaratId) {
         modaratService.delete(authenticatedUser.getUserId(), modaratId);
-        return ResponseEntity.ok(new BaseResponse<>(ErrorCode.SUCCESS));
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "모다라트 수정", description = "입력값을 이용해 모다라트를 수정합니다",
             security = @SecurityRequirement(name = "Bearer Authentication"),
             responses = {
-                    @ApiResponse(responseCode = "201", description = "모각 수정 성공"),
+                    @ApiResponse(responseCode = "200", description = "모다라트 수정 성공"),
             })
     @PutMapping("/{modaratId}")
     public ResponseEntity<BaseResponse<ModaratDto>> updateModarat(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,

--- a/src/main/java/com/mogak/spring/web/controller/MogakController.java
+++ b/src/main/java/com/mogak/spring/web/controller/MogakController.java
@@ -74,8 +74,9 @@ public class MogakController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PutMapping("/mogaks")
-    public ResponseEntity<BaseResponse<MogakResponseDto.GetMogakDto>> updateMogak(@Valid @RequestBody MogakRequestDto.UpdateDto request) {
-        return ResponseEntity.ok(new BaseResponse<>(mogakService.updateMogak(request)));
+    public ResponseEntity<BaseResponse<MogakResponseDto.GetMogakDto>> updateMogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                                                  @Valid @RequestBody MogakRequestDto.UpdateDto request) {
+        return ResponseEntity.ok(new BaseResponse<>(mogakService.updateMogak(authenticatedUser.getUserId(), request)));
     }
 
     @Operation(summary = "모각 조회", description = "입력값을 이용해 모각을 조회합니다",
@@ -102,8 +103,9 @@ public class MogakController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @DeleteMapping("/mogaks/{mogakId}")
-    public ResponseEntity<BaseResponse<ErrorCode>> deleteMogak(@PathVariable Long mogakId) {
-        mogakService.deleteMogak(mogakId);
+    public ResponseEntity<BaseResponse<ErrorCode>> deleteMogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                               @PathVariable Long mogakId) {
+        mogakService.deleteMogak(authenticatedUser.getUserId(), mogakId);
         return ResponseEntity.ok(new BaseResponse<>(ErrorCode.SUCCESS));
     }
 

--- a/src/main/java/com/mogak/spring/web/controller/PostController.java
+++ b/src/main/java/com/mogak/spring/web/controller/PostController.java
@@ -19,8 +19,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -34,7 +34,7 @@ import static com.mogak.spring.web.dto.postdto.PostResponseDto.*;
 public class PostController {
     private final PostService postService;
     private final StorageService storageService;
-    private static String dirName = "img";
+    private static final String DIR_NAME = "img";
 
     //create
     @Operation(summary = "회고록 생성", description = "회고록을 생성합니다",
@@ -52,7 +52,8 @@ public class PostController {
                                                                   @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                   @RequestPart PostRequestDto.CreatePostDto request,
                                                                   @RequestPart(required = true) List<MultipartFile> multipartFile) {
-        List<CreatePostImgDto> postImgDtoList = storageService.uploadImg(multipartFile, dirName);
+        postService.validateCreateAccess(authenticatedUser.getUserId(), request, multipartFile, mogakId);
+        List<CreatePostImgDto> postImgDtoList = storageService.uploadImg(multipartFile, DIR_NAME);
         Post post = postService.create(authenticatedUser.getUserId(), request, postImgDtoList, mogakId);
         return ResponseEntity.ok(new BaseResponse<>(PostConverter.toCreatePostDto(post)));
     }
@@ -72,9 +73,10 @@ public class PostController {
             })
     @GetMapping("/api/mogaks/{mogakId}/posts")
     public ResponseEntity<BaseResponse<Slice<GetPostDto>>> getPostList(@PathVariable Long mogakId,
+                                                                       @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                        @RequestParam(value = "page", defaultValue = "0") int page,
                                                                        @RequestParam(value = "size") int size) {
-        Slice<Post> posts = postService.getAllPosts(page, mogakId, size);
+        Slice<Post> posts = postService.getAllPosts(authenticatedUser.getUserId(), page, mogakId, size);
         //다음페이지 존재 여부 전달 필요
         return ResponseEntity.ok(new BaseResponse<>(PostConverter.toPostPagingDto(posts)));
     }
@@ -89,8 +91,9 @@ public class PostController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @GetMapping("/api/mogaks/posts/{postId}")
-    public ResponseEntity<BaseResponse<PostDto>> getPostDetail(@PathVariable Long postId) {
-        Post post = postService.findById(postId);
+    public ResponseEntity<BaseResponse<PostDto>> getPostDetail(@PathVariable Long postId,
+                                                               @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        Post post = postService.findById(authenticatedUser.getUserId(), postId);
         List<String> imgUrls = postService.findNotThumbnailImg(post); //썸네일은 제외하고 보여주기
         return ResponseEntity.ok(new BaseResponse<>(PostConverter.toPostDto(post, imgUrls)));
     }
@@ -108,8 +111,9 @@ public class PostController {
             })
     @PutMapping("/api/mogaks/posts/{postId}")
     public ResponseEntity<BaseResponse<UpdatePostDto>> updatePost(@PathVariable Long postId,
+                                                                  @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                   @RequestBody PostRequestDto.UpdatePostDto request) {
-        Post post = postService.update(postId, request);
+        Post post = postService.update(authenticatedUser.getUserId(), postId, request);
         return ResponseEntity.ok(new BaseResponse<>(PostConverter.toUpdatePostDto(post)));
     }
 
@@ -123,11 +127,12 @@ public class PostController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @DeleteMapping("/api/mogaks/posts/{postId}")
-    public ResponseEntity<BaseResponse<DeletePostDto>> deletePost(@PathVariable Long postId) {
-        Post post = postService.findById(postId);
+    public ResponseEntity<BaseResponse<DeletePostDto>> deletePost(@PathVariable Long postId,
+                                                                  @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        Post post = postService.findById(authenticatedUser.getUserId(), postId);
         List<PostImg> postImgList = postService.findAllImgByPost(post);
-        storageService.deleteImg(postImgList, dirName);
-        postService.delete(postId);
+        storageService.deleteImg(postImgList, DIR_NAME);
+        postService.delete(authenticatedUser.getUserId(), postId);
         return ResponseEntity.ok(new BaseResponse<>(PostConverter.toDeletePostDto()));
     }
 

--- a/src/test/java/com/mogak/spring/integration/CoreFlowIntegrationTest.java
+++ b/src/test/java/com/mogak/spring/integration/CoreFlowIntegrationTest.java
@@ -89,9 +89,9 @@ class CoreFlowIntegrationTest {
                 .color("#1234")
                 .build());
 
-        JogakResponseDto.CreateJogakDto createdJogak = jogakService.createJogak(createOneTimeJogakRequest(mogak.getId(), "문제풀이", LocalDate.now()));
-        JogakResponseDto.JogakDailyJogakDto started = jogakService.startJogak(createdJogak.getJogakId());
-        JogakResponseDto.JogakDailyJogakDto succeeded = jogakService.successJogak(started.getDailyJogakId());
+        JogakResponseDto.CreateJogakDto createdJogak = jogakService.createJogak(userId, createOneTimeJogakRequest(mogak.getId(), "문제풀이", LocalDate.now()));
+        JogakResponseDto.JogakDailyJogakDto started = jogakService.startJogak(userId, createdJogak.getJogakId());
+        JogakResponseDto.JogakDailyJogakDto succeeded = jogakService.successJogak(userId, started.getDailyJogakId());
 
         Jogak persistedJogak = jogakRepository.findById(createdJogak.getJogakId()).orElseThrow();
         DailyJogak persistedDailyJogak = dailyJogakRepository.findById(started.getDailyJogakId()).orElseThrow();
@@ -120,7 +120,7 @@ class CoreFlowIntegrationTest {
                 .color("#1234")
                 .build()).getId()).orElseThrow();
 
-        JogakResponseDto.CreateJogakDto createdJogak = jogakService.createJogak(createRoutineJogakRequest(
+        JogakResponseDto.CreateJogakDto createdJogak = jogakService.createJogak(user.getId(), createRoutineJogakRequest(
                 mogak.getId(),
                 "루틴 조각",
                 LocalDate.now(),
@@ -154,10 +154,10 @@ class CoreFlowIntegrationTest {
                 .color("#1234")
                 .build());
 
-        JogakResponseDto.CreateJogakDto createdJogak = jogakService.createJogak(createOneTimeJogakRequest(mogak.getId(), "임시 조각", LocalDate.now()));
-        JogakResponseDto.JogakDailyJogakDto started = jogakService.startJogak(createdJogak.getJogakId());
+        JogakResponseDto.CreateJogakDto createdJogak = jogakService.createJogak(user.getId(), createOneTimeJogakRequest(mogak.getId(), "임시 조각", LocalDate.now()));
+        JogakResponseDto.JogakDailyJogakDto started = jogakService.startJogak(user.getId(), createdJogak.getJogakId());
 
-        mogakService.deleteMogak(mogak.getId());
+        mogakService.deleteMogak(user.getId(), mogak.getId());
         entityManager.flush();
         entityManager.clear();
 

--- a/src/test/java/com/mogak/spring/repository/DailyJogakRepositoryTest.java
+++ b/src/test/java/com/mogak/spring/repository/DailyJogakRepositoryTest.java
@@ -84,7 +84,7 @@ class DailyJogakRepositoryTest {
     }
 
     @Test
-    @DisplayName("그래프 조회 메서드는 조각과 상위 사용자 정보를 함께 반환한다")
+    @DisplayName("그래프 조회 메서드는 조각 owner 검증과 응답 변환에 필요한 정보를 함께 반환한다")
     void findByIdWithJogakGraph() {
         User user = persistUser("graph@test.com");
         Modarat modarat = entityManager.persist(TestFixtureFactory.modarat(null, user, "메인", "#1111"));
@@ -99,8 +99,9 @@ class DailyJogakRepositoryTest {
         DailyJogak result = dailyJogakRepository.findByIdWithJogakGraph(dailyJogak.getId()).orElseThrow();
 
         assertThat(result.getJogak().getUser().getId()).isEqualTo(user.getId());
+        assertThat(result.getJogak().getMogak().getTitle()).isEqualTo("정보처리기사");
+        assertThat(result.getJogak().getCategory().getName()).isEqualTo("자격증");
         assertThat(result.getTitle()).isEqualTo("문제풀이");
-        assertThat(result.getMogak().getTitle()).isEqualTo("정보처리기사");
     }
 
     private User persistUser(String email) {

--- a/src/test/java/com/mogak/spring/repository/DailyJogakRepositoryTest.java
+++ b/src/test/java/com/mogak/spring/repository/DailyJogakRepositoryTest.java
@@ -83,6 +83,26 @@ class DailyJogakRepositoryTest {
         assertThat(result.getTitle()).isEqualTo("문제풀이");
     }
 
+    @Test
+    @DisplayName("그래프 조회 메서드는 조각과 상위 사용자 정보를 함께 반환한다")
+    void findByIdWithJogakGraph() {
+        User user = persistUser("graph@test.com");
+        Modarat modarat = entityManager.persist(TestFixtureFactory.modarat(null, user, "메인", "#1111"));
+        MogakCategory category = entityManager.persist(TestFixtureFactory.category(null, "자격증"));
+        Mogak mogak = entityManager.persist(TestFixtureFactory.mogak(null, user, modarat, category, "정보처리기사", "#aaaa"));
+        Jogak jogak = entityManager.persist(TestFixtureFactory.jogak(null, mogak, "문제풀이", false, LocalDate.now(), null, 0));
+        DailyJogak dailyJogak = entityManager.persist(TestFixtureFactory.dailyJogak(null, jogak, false));
+        TestFixtureFactory.setCreatedAt(dailyJogak, LocalDate.of(2026, 3, 26).atTime(10, 0));
+        entityManager.flush();
+        entityManager.clear();
+
+        DailyJogak result = dailyJogakRepository.findByIdWithJogakGraph(dailyJogak.getId()).orElseThrow();
+
+        assertThat(result.getJogak().getUser().getId()).isEqualTo(user.getId());
+        assertThat(result.getTitle()).isEqualTo("문제풀이");
+        assertThat(result.getMogak().getTitle()).isEqualTo("정보처리기사");
+    }
+
     private User persistUser(String email) {
         Job job = entityManager.persist(TestFixtureFactory.job("개발/데이터"));
         Address address = entityManager.persist(TestFixtureFactory.address("서울특별시"));

--- a/src/test/java/com/mogak/spring/service/JogakServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/JogakServiceImplTest.java
@@ -9,23 +9,19 @@ import com.mogak.spring.domain.mogak.Mogak;
 import com.mogak.spring.domain.mogak.MogakCategory;
 import com.mogak.spring.domain.user.User;
 import com.mogak.spring.global.ErrorCode;
-import com.mogak.spring.repository.DailyJogakRepository;
-import com.mogak.spring.repository.JogakPeriodRepository;
-import com.mogak.spring.repository.JogakRepository;
-import com.mogak.spring.repository.MogakRepository;
-import com.mogak.spring.repository.PeriodRepository;
-import com.mogak.spring.repository.UserRepository;
+import com.mogak.spring.repository.*;
 import com.mogak.spring.support.ErrorCodeAssertions;
 import com.mogak.spring.support.TestFixtureFactory;
 import com.mogak.spring.web.dto.jogakdto.JogakRequestDto;
 import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -34,9 +30,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class JogakServiceImplTest {
@@ -61,15 +55,15 @@ class JogakServiceImplTest {
         TestFixtureFactory.attachJogaks(mogak, List.of());
         Jogak saved = TestFixtureFactory.jogak(10L, mogak, "일회성 조각", false, LocalDate.of(2026, 3, 26), null, 0);
         JogakRequestDto.CreateJogakDto request = new JogakRequestDto.CreateJogakDto();
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "mogakId", 2L);
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "title", "일회성 조각");
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "isRoutine", false);
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "today", LocalDate.of(2026, 3, 26));
+        ReflectionTestUtils.setField(request, "mogakId", 2L);
+        ReflectionTestUtils.setField(request, "title", "일회성 조각");
+        ReflectionTestUtils.setField(request, "isRoutine", false);
+        ReflectionTestUtils.setField(request, "today", LocalDate.of(2026, 3, 26));
 
         when(mogakRepository.findById(2L)).thenReturn(Optional.of(mogak));
         when(jogakRepository.save(any(Jogak.class))).thenReturn(saved);
 
-        JogakResponseDto.CreateJogakDto result = jogakService.createJogak(request);
+        JogakResponseDto.CreateJogakDto result = jogakService.createJogak(1L, request);
 
         assertThat(result.getJogakId()).isEqualTo(10L);
         assertThat(result.getIsRoutine()).isFalse();
@@ -89,18 +83,18 @@ class JogakServiceImplTest {
         Period monday = TestFixtureFactory.period(1, "MONDAY");
         Period tuesday = TestFixtureFactory.period(2, "TUESDAY");
         JogakRequestDto.CreateJogakDto request = new JogakRequestDto.CreateJogakDto();
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "mogakId", 2L);
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "title", "루틴 조각");
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "isRoutine", true);
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "today", today);
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "days", List.of("MONDAY", "TUESDAY"));
+        ReflectionTestUtils.setField(request, "mogakId", 2L);
+        ReflectionTestUtils.setField(request, "title", "루틴 조각");
+        ReflectionTestUtils.setField(request, "isRoutine", true);
+        ReflectionTestUtils.setField(request, "today", today);
+        ReflectionTestUtils.setField(request, "days", List.of("MONDAY", "TUESDAY"));
 
         when(mogakRepository.findById(2L)).thenReturn(Optional.of(mogak));
         when(jogakRepository.save(any(Jogak.class))).thenReturn(saved);
         when(periodRepository.findOneByDays("MONDAY")).thenReturn(Optional.of(monday));
         when(periodRepository.findOneByDays("TUESDAY")).thenReturn(Optional.of(tuesday));
 
-        JogakResponseDto.CreateJogakDto result = jogakService.createJogak(request);
+        JogakResponseDto.CreateJogakDto result = jogakService.createJogak(1L, request);
 
         assertThat(result.getIsRoutine()).isTrue();
         assertThat(result.getDays()).containsExactly("MONDAY", "TUESDAY");
@@ -118,17 +112,56 @@ class JogakServiceImplTest {
         TestFixtureFactory.attachJogaks(mogak, List.of());
         Jogak saved = TestFixtureFactory.jogak(10L, mogak, "루틴 조각", true, LocalDate.of(2026, 3, 26), null, 0);
         JogakRequestDto.CreateJogakDto request = new JogakRequestDto.CreateJogakDto();
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "mogakId", 2L);
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "title", "루틴 조각");
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "isRoutine", true);
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "today", LocalDate.of(2026, 3, 26));
+        ReflectionTestUtils.setField(request, "mogakId", 2L);
+        ReflectionTestUtils.setField(request, "title", "루틴 조각");
+        ReflectionTestUtils.setField(request, "isRoutine", true);
+        ReflectionTestUtils.setField(request, "today", LocalDate.of(2026, 3, 26));
 
         when(mogakRepository.findById(2L)).thenReturn(Optional.of(mogak));
         when(jogakRepository.save(any(Jogak.class))).thenReturn(saved);
 
-        Throwable throwable = org.assertj.core.api.Assertions.catchThrowable(() -> jogakService.createJogak(request));
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.createJogak(1L, request));
 
         ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.NOT_VALID_PERIOD);
+    }
+
+    @Test
+    @DisplayName("타인 모각에 조각 생성 요청을 하면 권한 오류를 반환한다")
+    void createJogakThrowsWhenOwnerMismatch() {
+        User owner = TestFixtureFactory.user(1L, "owner@test.com", "owner", null, null);
+        User other = TestFixtureFactory.user(2L, "other@test.com", "other", null, null);
+        Modarat modarat = TestFixtureFactory.modarat(1L, owner, "모다라트", "#0000");
+        MogakCategory category = TestFixtureFactory.category(1, "자격증");
+        Mogak mogak = TestFixtureFactory.mogak(2L, owner, modarat, category, "모각", "#1234");
+        TestFixtureFactory.attachJogaks(mogak, List.of());
+        JogakRequestDto.CreateJogakDto request = new JogakRequestDto.CreateJogakDto();
+        ReflectionTestUtils.setField(request, "mogakId", 2L);
+        ReflectionTestUtils.setField(request, "title", "조각");
+        ReflectionTestUtils.setField(request, "isRoutine", false);
+        ReflectionTestUtils.setField(request, "today", LocalDate.of(2026, 3, 26));
+
+        when(mogakRepository.findById(2L)).thenReturn(Optional.of(mogak));
+
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.createJogak(other.getId(), request));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        verify(jogakRepository, times(0)).save(any(Jogak.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모각에 조각 생성 요청을 하면 기존 not-exist 응답을 반환한다")
+    void createJogakThrowsWhenMogakMissing() {
+        JogakRequestDto.CreateJogakDto request = new JogakRequestDto.CreateJogakDto();
+        ReflectionTestUtils.setField(request, "mogakId", 999L);
+        ReflectionTestUtils.setField(request, "title", "조각");
+        ReflectionTestUtils.setField(request, "isRoutine", false);
+        ReflectionTestUtils.setField(request, "today", LocalDate.of(2026, 3, 26));
+
+        when(mogakRepository.findById(999L)).thenReturn(Optional.empty());
+
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.createJogak(1L, request));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.NOT_EXIST_MOGAK);
     }
 
     @Test
@@ -143,14 +176,14 @@ class JogakServiceImplTest {
                 .collect(Collectors.toList());
         TestFixtureFactory.attachJogaks(mogak, existing);
         JogakRequestDto.CreateJogakDto request = new JogakRequestDto.CreateJogakDto();
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "mogakId", 2L);
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "title", "새 조각");
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "isRoutine", false);
-        org.springframework.test.util.ReflectionTestUtils.setField(request, "today", LocalDate.of(2026, 3, 26));
+        ReflectionTestUtils.setField(request, "mogakId", 2L);
+        ReflectionTestUtils.setField(request, "title", "새 조각");
+        ReflectionTestUtils.setField(request, "isRoutine", false);
+        ReflectionTestUtils.setField(request, "today", LocalDate.of(2026, 3, 26));
 
         when(mogakRepository.findById(2L)).thenReturn(Optional.of(mogak));
 
-        Throwable throwable = org.assertj.core.api.Assertions.catchThrowable(() -> jogakService.createJogak(request));
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.createJogak(1L, request));
 
         ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.EXCEED_MAX_JOGAK);
     }
@@ -190,7 +223,7 @@ class JogakServiceImplTest {
                 .thenReturn(Optional.empty());
         when(dailyJogakRepository.save(any(DailyJogak.class))).thenReturn(dailyJogak);
 
-        JogakResponseDto.JogakDailyJogakDto result = jogakService.startJogak(10L);
+        JogakResponseDto.JogakDailyJogakDto result = jogakService.startJogak(1L, 10L);
 
         assertThat(result.getDailyJogakId()).isEqualTo(100L);
         assertThat(result.getAchievements()).isZero();
@@ -209,9 +242,29 @@ class JogakServiceImplTest {
         when(dailyJogakRepository.findByCreatedAtBetweenAndId(LocalDate.now().atStartOfDay(), LocalDate.now().atStartOfDay().plusDays(1), jogak))
                 .thenReturn(Optional.of(TestFixtureFactory.dailyJogak(100L, jogak, false)));
 
-        Throwable throwable = org.assertj.core.api.Assertions.catchThrowable(() -> jogakService.startJogak(10L));
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.startJogak(1L, 10L));
 
         ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.ALREADY_START_JOGAK);
+    }
+
+    @Test
+    @DisplayName("타인 조각 시작 요청을 하면 권한 오류를 반환한다")
+    void startJogakThrowsWhenOwnerMismatch() {
+        User owner = TestFixtureFactory.user(1L, "owner@test.com", "owner", null, null);
+        User other = TestFixtureFactory.user(2L, "other@test.com", "other", null, null);
+        Jogak jogak = TestFixtureFactory.jogak(10L, TestFixtureFactory.mogak(2L,
+                owner,
+                TestFixtureFactory.modarat(1L, owner, "모다라트", "#0000"),
+                TestFixtureFactory.category(1, "자격증"),
+                "모각",
+                "#1234"), "조각", false, LocalDate.now(), null, 0);
+
+        when(jogakRepository.findById(10L)).thenReturn(Optional.of(jogak));
+
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.startJogak(other.getId(), 10L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        verify(dailyJogakRepository, times(0)).save(any(DailyJogak.class));
     }
 
     @Test
@@ -225,10 +278,9 @@ class JogakServiceImplTest {
                 "#1234"), "조각", false, LocalDate.now(), null, 0);
         DailyJogak dailyJogak = TestFixtureFactory.dailyJogak(100L, jogak, false);
 
-        when(dailyJogakRepository.findById(100L)).thenReturn(Optional.of(dailyJogak));
-        when(jogakRepository.findByDailyJogak(dailyJogak)).thenReturn(Optional.of(jogak));
+        when(dailyJogakRepository.findByIdWithJogakGraph(100L)).thenReturn(Optional.of(dailyJogak));
 
-        JogakResponseDto.JogakDailyJogakDto result = jogakService.successJogak(100L);
+        JogakResponseDto.JogakDailyJogakDto result = jogakService.successJogak(1L, 100L);
 
         assertThat(result.getIsAchievement()).isTrue();
         assertThat(result.getAchievements()).isEqualTo(1);
@@ -245,12 +297,146 @@ class JogakServiceImplTest {
                 "#1234"), "조각", false, LocalDate.now(), null, 1);
         DailyJogak dailyJogak = TestFixtureFactory.dailyJogak(100L, jogak, false);
 
-        when(dailyJogakRepository.findById(100L)).thenReturn(Optional.of(dailyJogak));
-        when(jogakRepository.findByDailyJogak(dailyJogak)).thenReturn(Optional.of(jogak));
+        when(dailyJogakRepository.findByIdWithJogakGraph(100L)).thenReturn(Optional.of(dailyJogak));
 
-        Throwable throwable = org.assertj.core.api.Assertions.catchThrowable(() -> jogakService.failJogak(100L));
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.failJogak(1L, 100L));
 
         ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.NOT_SUCCESS_DAILY_JOGAK);
+    }
+
+    @Test
+    @DisplayName("타인 데일리 조각 성공 요청을 하면 권한 오류를 반환한다")
+    void successJogakThrowsWhenOwnerMismatch() {
+        User owner = TestFixtureFactory.user(1L, "owner@test.com", "owner", null, null);
+        User other = TestFixtureFactory.user(2L, "other@test.com", "other", null, null);
+        Jogak jogak = TestFixtureFactory.jogak(10L, TestFixtureFactory.mogak(2L,
+                owner,
+                TestFixtureFactory.modarat(1L, owner, "모다라트", "#0000"),
+                TestFixtureFactory.category(1, "자격증"),
+                "모각",
+                "#1234"), "조각", false, LocalDate.now(), null, 0);
+        DailyJogak dailyJogak = TestFixtureFactory.dailyJogak(100L, jogak, false);
+
+        when(dailyJogakRepository.findByIdWithJogakGraph(100L)).thenReturn(Optional.of(dailyJogak));
+
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.successJogak(other.getId(), 100L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+    }
+
+    @Test
+    @DisplayName("타인 데일리 조각 실패 요청을 하면 권한 오류를 반환한다")
+    void failJogakThrowsWhenOwnerMismatch() {
+        User owner = TestFixtureFactory.user(1L, "owner@test.com", "owner", null, null);
+        User other = TestFixtureFactory.user(2L, "other@test.com", "other", null, null);
+        Jogak jogak = TestFixtureFactory.jogak(10L, TestFixtureFactory.mogak(2L,
+                owner,
+                TestFixtureFactory.modarat(1L, owner, "모다라트", "#0000"),
+                TestFixtureFactory.category(1, "자격증"),
+                "모각",
+                "#1234"), "조각", false, LocalDate.now(), null, 1);
+        DailyJogak dailyJogak = TestFixtureFactory.dailyJogak(100L, jogak, false);
+
+        when(dailyJogakRepository.findByIdWithJogakGraph(100L)).thenReturn(Optional.of(dailyJogak));
+
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.failJogak(other.getId(), 100L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+    }
+
+    @Test
+    @DisplayName("타인 조각 상세 조회를 하면 권한 오류를 반환한다")
+    void getJogakDetailThrowsWhenOwnerMismatch() {
+        User owner = TestFixtureFactory.user(1L, "owner@test.com", "owner", null, null);
+        User other = TestFixtureFactory.user(2L, "other@test.com", "other", null, null);
+        Jogak jogak = TestFixtureFactory.jogak(10L, TestFixtureFactory.mogak(2L,
+                owner,
+                TestFixtureFactory.modarat(1L, owner, "모다라트", "#0000"),
+                TestFixtureFactory.category(1, "자격증"),
+                "모각",
+                "#1234"), "조각", true, LocalDate.now(), null, 0);
+
+        when(jogakRepository.findById(10L)).thenReturn(Optional.of(jogak));
+
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.getJogakDetail(other.getId(), 10L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 조각 상세 조회는 기존 not-exist 응답을 반환한다")
+    void getJogakDetailThrowsWhenJogakMissing() {
+        when(jogakRepository.findById(10L)).thenReturn(Optional.empty());
+
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.getJogakDetail(1L, 10L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.NOT_EXIST_JOGAK);
+    }
+
+    @Test
+    @DisplayName("타인 조각 수정 요청을 하면 권한 오류를 반환한다")
+    void updateJogakThrowsWhenOwnerMismatch() {
+        User owner = TestFixtureFactory.user(1L, "owner@test.com", "owner", null, null);
+        User other = TestFixtureFactory.user(2L, "other@test.com", "other", null, null);
+        Jogak jogak = TestFixtureFactory.jogak(10L, TestFixtureFactory.mogak(2L,
+                owner,
+                TestFixtureFactory.modarat(1L, owner, "모다라트", "#0000"),
+                TestFixtureFactory.category(1, "자격증"),
+                "모각",
+                "#1234"), "조각", false, LocalDate.now(), null, 0);
+        JogakRequestDto.UpdateJogakDto request = new JogakRequestDto.UpdateJogakDto();
+        ReflectionTestUtils.setField(request, "title", "수정");
+        ReflectionTestUtils.setField(request, "isRoutine", false);
+
+        when(jogakRepository.findById(10L)).thenReturn(Optional.of(jogak));
+
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.updateJogak(other.getId(), 10L, request));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 조각 수정은 기존 not-exist 응답을 반환한다")
+    void updateJogakThrowsWhenJogakMissing() {
+        JogakRequestDto.UpdateJogakDto request = new JogakRequestDto.UpdateJogakDto();
+        ReflectionTestUtils.setField(request, "title", "수정");
+        ReflectionTestUtils.setField(request, "isRoutine", false);
+
+        when(jogakRepository.findById(10L)).thenReturn(Optional.empty());
+
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.updateJogak(1L, 10L, request));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.NOT_EXIST_JOGAK);
+    }
+
+    @Test
+    @DisplayName("타인 조각 삭제 요청을 하면 권한 오류를 반환한다")
+    void deleteJogakThrowsWhenOwnerMismatch() {
+        User owner = TestFixtureFactory.user(1L, "owner@test.com", "owner", null, null);
+        User other = TestFixtureFactory.user(2L, "other@test.com", "other", null, null);
+        Jogak jogak = TestFixtureFactory.jogak(10L, TestFixtureFactory.mogak(2L,
+                owner,
+                TestFixtureFactory.modarat(1L, owner, "모다라트", "#0000"),
+                TestFixtureFactory.category(1, "자격증"),
+                "모각",
+                "#1234"), "조각", false, LocalDate.now(), null, 0);
+
+        when(jogakRepository.findById(10L)).thenReturn(Optional.of(jogak));
+
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.deleteJogak(other.getId(), 10L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        verify(jogakRepository, times(0)).deleteById(10L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 조각 삭제는 기존 not-exist 응답을 반환한다")
+    void deleteJogakThrowsWhenJogakMissing() {
+        when(jogakRepository.findById(10L)).thenReturn(Optional.empty());
+
+        Throwable throwable = Assertions.catchThrowable(() -> jogakService.deleteJogak(1L, 10L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.NOT_EXIST_JOGAK);
     }
 
     @Test

--- a/src/test/java/com/mogak/spring/service/ModaratServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/ModaratServiceImplTest.java
@@ -1,0 +1,110 @@
+package com.mogak.spring.service;
+
+import com.mogak.spring.auth.AppleOAuthUserProvider;
+import com.mogak.spring.domain.modarat.Modarat;
+import com.mogak.spring.domain.mogak.Mogak;
+import com.mogak.spring.domain.mogak.MogakCategory;
+import com.mogak.spring.domain.user.Address;
+import com.mogak.spring.domain.user.Job;
+import com.mogak.spring.domain.user.User;
+import com.mogak.spring.global.ErrorCode;
+import com.mogak.spring.repository.*;
+import com.mogak.spring.support.ErrorCodeAssertions;
+import com.mogak.spring.support.TestFixtureFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@Transactional
+@SpringBootTest
+@ActiveProfiles("test")
+class ModaratServiceImplTest {
+
+    @Autowired private ModaratService modaratService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private ModaratRepository modaratRepository;
+    @Autowired private MogakRepository mogakRepository;
+    @Autowired private JobRepository jobRepository;
+    @Autowired private AddressRepository addressRepository;
+    @Autowired private MogakCategoryRepository mogakCategoryRepository;
+
+    @MockitoSpyBean private MogakService mogakService;
+    @MockitoBean private AppleOAuthUserProvider appleOAuthUserProvider;
+    @MockitoBean private StorageService storageService;
+
+    @Test
+    @DisplayName("다른 사용자의 모다라트를 조회하면 권한 오류를 반환한다")
+    void getDetailThrowsWhenNotOwner() {
+        User requester = saveUser("user@test.com", "user");
+        User owner = saveUser("owner@test.com", "owner");
+        Modarat modarat = modaratRepository.save(TestFixtureFactory.modarat(null, owner, "메인 모다라트", "#0000"));
+
+        Throwable throwable = org.assertj.core.api.Assertions.catchThrowable(() -> modaratService.getDetailModarat(requester.getId(), modarat.getId()));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+    }
+
+    @Test
+    @DisplayName("요청자 id가 없으면 모다라트 조회 권한 오류를 반환한다")
+    void getDetailThrowsWhenRequesterIsNull() {
+        User owner = saveUser("owner@test.com", "owner");
+        Modarat modarat = modaratRepository.save(TestFixtureFactory.modarat(null, owner, "메인 모다라트", "#0000"));
+
+        Throwable throwable = org.assertj.core.api.Assertions.catchThrowable(() -> modaratService.getDetailModarat(null, modarat.getId()));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 모다라트를 삭제하면 권한 오류를 반환한다")
+    void deleteThrowsWhenNotOwner() {
+        User requester = saveUser("user@test.com", "user");
+        User owner = saveUser("owner@test.com", "owner");
+        Modarat modarat = modaratRepository.save(TestFixtureFactory.modarat(null, owner, "메인 모다라트", "#0000"));
+
+        Throwable throwable = org.assertj.core.api.Assertions.catchThrowable(() -> modaratService.delete(requester.getId(), modarat.getId()));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        verify(mogakService, never()).deleteMogakCascadeAfterParentAuthorization(anyLong());
+    }
+
+    @Test
+    @DisplayName("모다라트를 삭제하면 내부 모각 삭제를 위임한 뒤 모다라트를 삭제한다")
+    void deleteModaratCascadesAfterAuthorization() {
+        User owner = saveUser("owner@test.com", "owner");
+        Modarat modarat = modaratRepository.save(TestFixtureFactory.modarat(null, owner, "메인 모다라트", "#0000"));
+        MogakCategory category = saveCategory("자격증");
+        Mogak first = mogakRepository.save(TestFixtureFactory.mogak(null, owner, modarat, category, "첫 모각", "#1111"));
+        Mogak second = mogakRepository.save(TestFixtureFactory.mogak(null, owner, modarat, category, "둘째 모각", "#2222"));
+        TestFixtureFactory.attachJogaks(first, List.of());
+        TestFixtureFactory.attachJogaks(second, List.of());
+
+        modaratService.delete(owner.getId(), modarat.getId());
+
+        verify(mogakService).deleteMogakCascadeAfterParentAuthorization(first.getId());
+        verify(mogakService).deleteMogakCascadeAfterParentAuthorization(second.getId());
+        org.assertj.core.api.Assertions.assertThat(modaratRepository.findById(modarat.getId())).isEmpty();
+    }
+
+    private User saveUser(String email, String nickname) {
+        Job job = jobRepository.findJobByName("개발/데이터").orElseGet(() -> jobRepository.save(TestFixtureFactory.job("개발/데이터")));
+        Address address = addressRepository.findAddressByName("서울특별시").orElseGet(() -> addressRepository.save(TestFixtureFactory.address("서울특별시")));
+        return userRepository.save(TestFixtureFactory.user(null, email, nickname, job, address));
+    }
+
+    private MogakCategory saveCategory(String name) {
+        return mogakCategoryRepository.findMogakCategoryByName(name)
+                .orElseGet(() -> mogakCategoryRepository.save(TestFixtureFactory.category(null, name)));
+    }
+}

--- a/src/test/java/com/mogak/spring/service/MogakServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/MogakServiceImplTest.java
@@ -75,6 +75,28 @@ class MogakServiceImplTest {
     }
 
     @Test
+    @DisplayName("다른 사용자의 모다라트에 모각을 생성하면 권한 오류를 반환한다")
+    void createThrowsWhenModaratNotOwned() {
+        User user = TestFixtureFactory.user(1L, "user@test.com", "tester", null, null);
+        User otherUser = TestFixtureFactory.user(2L, "other@test.com", "other", null, null);
+        Modarat modarat = TestFixtureFactory.modarat(3L, otherUser, "메인 모다라트", "#0000");
+        MogakRequestDto.CreateDto request = MogakRequestDto.CreateDto.builder()
+                .modaratId(3L)
+                .title("정보처리기사")
+                .bigCategory("자격증")
+                .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(modaratRepository.findById(3L)).thenReturn(Optional.of(modarat));
+
+        Throwable throwable = org.assertj.core.api.Assertions.catchThrowable(() -> mogakService.create(1L, request));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        verify(mogakRepository, org.mockito.Mockito.never()).findAllByModaratId(3L);
+        verify(mogakRepository, org.mockito.Mockito.never()).save(org.mockito.ArgumentMatchers.any(Mogak.class));
+    }
+
+    @Test
     @DisplayName("모다라트에 모각이 8개 있으면 새 모각을 생성할 수 없다")
     void createThrowsWhenMaxExceeded() {
         User user = TestFixtureFactory.user(1L, "user@test.com", "tester", null, null);
@@ -120,7 +142,7 @@ class MogakServiceImplTest {
                 .color("#9999")
                 .build();
 
-        MogakResponseDto.GetMogakDto result = mogakService.updateMogak(request);
+        MogakResponseDto.GetMogakDto result = mogakService.updateMogak(1L, request);
 
         assertThat(result.getTitle()).isEqualTo("새 제목");
         assertThat(mogak.getBigCategory()).isEqualTo(newCategory);
@@ -142,14 +164,71 @@ class MogakServiceImplTest {
         when(mogakRepository.findById(2L)).thenReturn(Optional.of(mogak));
         when(jogakRepository.findAllByMogak(mogak)).thenReturn(List.of(first, second));
 
-        mogakService.deleteMogak(2L);
+        mogakService.deleteMogak(1L, 2L);
 
-        verify(jogakService).deleteJogak(10L);
-        verify(jogakService).deleteJogak(11L);
+        verify(jogakService).deleteJogakCascadeAfterParentAuthorization(10L);
+        verify(jogakService).deleteJogakCascadeAfterParentAuthorization(11L);
         verify(jogakRepository).findAllByMogak(mogak);
         verify(dailyJogakRepository).flush();
         verify(jogakRepository).flush();
         verify(mogakRepository).deleteById(2L);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 모각을 수정하면 권한 오류를 반환한다")
+    void updateThrowsWhenMogakNotOwned() {
+        User user = TestFixtureFactory.user(1L, "user@test.com", "tester", null, null);
+        User otherUser = TestFixtureFactory.user(2L, "other@test.com", "other", null, null);
+        Modarat modarat = TestFixtureFactory.modarat(1L, otherUser, "모다라트", "#0000");
+        MogakCategory category = TestFixtureFactory.category(1, "자격증");
+        Mogak mogak = TestFixtureFactory.mogak(2L, otherUser, modarat, category, "원래 제목", "#1234");
+        MogakRequestDto.UpdateDto request = MogakRequestDto.UpdateDto.builder()
+                .mogakId(2L)
+                .title("새 제목")
+                .bigCategory("자격증")
+                .smallCategory("백엔드")
+                .color("#9999")
+                .build();
+
+        when(mogakRepository.findById(2L)).thenReturn(Optional.of(mogak));
+
+        Throwable throwable = org.assertj.core.api.Assertions.catchThrowable(() -> mogakService.updateMogak(1L, request));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        verify(categoryRepository, org.mockito.Mockito.never()).findMogakCategoryByName("자격증");
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 모각을 삭제하면 권한 오류를 반환한다")
+    void deleteThrowsWhenMogakNotOwned() {
+        User otherUser = TestFixtureFactory.user(2L, "other@test.com", "other", null, null);
+        Modarat modarat = TestFixtureFactory.modarat(1L, otherUser, "모다라트", "#0000");
+        MogakCategory category = TestFixtureFactory.category(1, "자격증");
+        Mogak mogak = TestFixtureFactory.mogak(2L, otherUser, modarat, category, "원래 제목", "#1234");
+
+        when(mogakRepository.findById(2L)).thenReturn(Optional.of(mogak));
+
+        Throwable throwable = org.assertj.core.api.Assertions.catchThrowable(() -> mogakService.deleteMogak(1L, 2L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        verify(jogakService, org.mockito.Mockito.never()).deleteJogakCascadeAfterParentAuthorization(org.mockito.ArgumentMatchers.anyLong());
+        verify(mogakRepository, org.mockito.Mockito.never()).deleteById(org.mockito.ArgumentMatchers.anyLong());
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 모다라트 모각 목록을 조회하면 권한 오류를 반환한다")
+    void getMogakDtoListThrowsWhenModaratNotOwned() {
+        User user = TestFixtureFactory.user(1L, "user@test.com", "tester", null, null);
+        User otherUser = TestFixtureFactory.user(2L, "other@test.com", "other", null, null);
+        Modarat modarat = TestFixtureFactory.modarat(3L, otherUser, "메인 모다라트", "#0000");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(modaratRepository.findById(3L)).thenReturn(Optional.of(modarat));
+
+        Throwable throwable = org.assertj.core.api.Assertions.catchThrowable(() -> mogakService.getMogakDtoList(1L, 3L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        verify(mogakRepository, org.mockito.Mockito.never()).findAllByModaratId(3L);
     }
 
     @Test

--- a/src/test/java/com/mogak/spring/service/PostServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/PostServiceImplTest.java
@@ -1,0 +1,211 @@
+package com.mogak.spring.service;
+
+import com.mogak.spring.domain.mogak.Mogak;
+import com.mogak.spring.domain.post.Post;
+import com.mogak.spring.domain.post.PostImg;
+import com.mogak.spring.domain.user.User;
+import com.mogak.spring.global.ErrorCode;
+import com.mogak.spring.repository.*;
+import com.mogak.spring.support.ErrorCodeAssertions;
+import com.mogak.spring.support.TestFixtureFactory;
+import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
+import com.mogak.spring.web.dto.postdto.PostRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceImplTest {
+
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private MogakRepository mogakRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PostImgRepository postImgRepository;
+    @Mock
+    private PostCommentRepository postCommentRepository;
+
+    @InjectMocks
+    private PostServiceImpl postService;
+
+    @Test
+    @DisplayName("게시글 생성 preflight는 다른 사용자의 모각이면 권한 예외를 반환한다")
+    void validateCreateAccessThrowsInvalidPermissionWhenMogakBelongsToOtherUser() {
+        User owner = user(1L, "owner@test.com");
+        User other = user(2L, "other@test.com");
+        Mogak mogak = mogak(10L, owner);
+        PostRequestDto.CreatePostDto request = createRequest("content");
+        List<MultipartFile> images = List.of(image("post.png"));
+
+        when(mogakRepository.findById(10L)).thenReturn(Optional.of(mogak));
+
+        Throwable throwable = catchThrowable(() -> postService.validateCreateAccess(2L, request, images, 10L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        verify(postRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("게시글 생성 preflight는 본문 길이가 초과되면 업로드 전에 예외를 반환한다")
+    void validateCreateAccessThrowsExceedMaxNumPostWhenContentsTooLong() {
+        User owner = user(1L, "owner@test.com");
+        Mogak mogak = mogak(10L, owner);
+        PostRequestDto.CreatePostDto request = createRequest("x".repeat(351));
+        List<MultipartFile> images = List.of(image("post.png"));
+
+        when(mogakRepository.findById(10L)).thenReturn(Optional.of(mogak));
+
+        Throwable throwable = catchThrowable(() -> postService.validateCreateAccess(1L, request, images, 10L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.EXCEED_MAX_NUM_POST);
+        verify(postRepository, never()).findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("게시글 생성에 성공하면 이미지와 게시글을 저장한다")
+    void createSavesPostAfterValidationWithImages() {
+        User writer = user(1L, "writer@test.com");
+        Mogak mogak = mogak(10L, writer);
+        PostRequestDto.CreatePostDto request = createRequest("content");
+        List<PostImgRequestDto.CreatePostImgDto> uploadedImages = List.of(
+                PostImgRequestDto.CreatePostImgDto.builder()
+                        .imgName("thumb.png")
+                        .imgUrl("https://example.com/thumb.png")
+                        .thumbnail(true)
+                        .build(),
+                PostImgRequestDto.CreatePostImgDto.builder()
+                        .imgName("body.png")
+                        .imgUrl("https://example.com/body.png")
+                        .thumbnail(false)
+                        .build()
+        );
+
+        when(mogakRepository.findById(10L)).thenReturn(Optional.of(mogak));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(writer));
+        when(postImgRepository.save(any(PostImg.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(postRepository.save(any(Post.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Post result = postService.create(1L, request, uploadedImages, 10L);
+
+        assertThat(result.getMogak()).isSameAs(mogak);
+        assertThat(result.getUser()).isSameAs(writer);
+        assertThat(result.getPostImgs()).hasSize(1);
+        assertThat(result.getPostThumbnailUrl()).isEqualTo("https://example.com/thumb.png");
+        verify(postImgRepository, times(2)).save(any(PostImg.class));
+        verify(postRepository).save(any(Post.class));
+    }
+
+    @Test
+    @DisplayName("모각 목록 조회는 owner가 아니면 권한 예외를 반환한다")
+    void getAllPostsThrowsInvalidPermissionWhenMogakBelongsToOtherUser() {
+        User owner = user(1L, "owner@test.com");
+        Mogak mogak = mogak(10L, owner);
+
+        when(mogakRepository.findById(10L)).thenReturn(Optional.of(mogak));
+
+        Throwable throwable = catchThrowable(() -> postService.getAllPosts(2L, 0, 10L, 10));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        verify(postRepository, never()).findAllPosts(anyLong(), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("게시글 상세 조회는 owner가 아니면 권한 예외를 반환한다")
+    void findByIdThrowsInvalidPermissionWhenPostBelongsToOtherUser() {
+        User owner = user(1L, "owner@test.com");
+        Post post = post(10L, owner);
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+
+        Throwable throwable = catchThrowable(() -> postService.findById(2L, 10L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+    }
+
+    @Test
+    @DisplayName("게시글 수정은 owner가 아니면 권한 예외를 반환하고 내용은 유지된다")
+    void updateThrowsInvalidPermissionWhenPostBelongsToOtherUser() {
+        User owner = user(1L, "owner@test.com");
+        Post post = post(10L, owner);
+        PostRequestDto.UpdatePostDto request = updateRequest("updated");
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+
+        Throwable throwable = catchThrowable(() -> postService.update(2L, 10L, request));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        assertThat(post.getContents()).isEqualTo("content");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글을 삭제하면 기존 not-exist 응답을 반환한다")
+    void deleteThrowsNotExistPostWhenMissing() {
+        when(postRepository.findById(10L)).thenReturn(Optional.empty());
+
+        Throwable throwable = catchThrowable(() -> postService.delete(1L, 10L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.NOT_EXIST_POST);
+        verify(postImgRepository, never()).deleteAllByPost(any(Post.class));
+        verify(postCommentRepository, never()).deleteAllByPost(any(Post.class));
+        verify(postRepository, never()).deleteById(anyLong());
+    }
+
+    private User user(Long id, String email) {
+        return TestFixtureFactory.user(id, email, "user" + id, null, null);
+    }
+
+    private Mogak mogak(Long id, User owner) {
+        return TestFixtureFactory.mogak(id, owner, TestFixtureFactory.modarat(1L, owner, "modarat", "#000000"), TestFixtureFactory.category(1, "자격증"), "mogak", "#112233");
+    }
+
+    private Post post(Long id, User owner) {
+        return Post.builder()
+                .id(id)
+                .mogak(mogak(10L, owner))
+                .user(owner)
+                .contents("content")
+                .postThumbnailUrl("https://example.com/thumb.png")
+                .validation("ACTIVE")
+                .viewCnt(0)
+                .build();
+    }
+
+    private PostRequestDto.CreatePostDto createRequest(String contents) {
+        PostRequestDto.CreatePostDto request = new PostRequestDto.CreatePostDto();
+        ReflectionTestUtils.setField(request, "contents", contents);
+        return request;
+    }
+
+    private PostRequestDto.UpdatePostDto updateRequest(String contents) {
+        PostRequestDto.UpdatePostDto request = new PostRequestDto.UpdatePostDto();
+        ReflectionTestUtils.setField(request, "contents", contents);
+        return request;
+    }
+
+    private MultipartFile image(String fileName) {
+        return new org.springframework.mock.web.MockMultipartFile(
+                "multipartFile",
+                fileName,
+                "image/png",
+                "png".getBytes()
+        );
+    }
+}

--- a/src/test/java/com/mogak/spring/service/PostServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/PostServiceImplTest.java
@@ -80,6 +80,22 @@ class PostServiceImplTest {
     }
 
     @Test
+    @DisplayName("게시글 생성 preflight는 본문이 없으면 입력값 오류를 반환한다")
+    void validateCreateAccessThrowsInvalidParameterWhenContentsMissing() {
+        User owner = user(1L, "owner@test.com");
+        Mogak mogak = mogak(10L, owner);
+        PostRequestDto.CreatePostDto request = createRequest(null);
+        List<MultipartFile> images = List.of(image("post.png"));
+
+        when(mogakRepository.findById(10L)).thenReturn(Optional.of(mogak));
+
+        Throwable throwable = catchThrowable(() -> postService.validateCreateAccess(1L, request, images, 10L));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PARAMETER_ERROR);
+        verify(postRepository, never()).findById(anyLong());
+    }
+
+    @Test
     @DisplayName("게시글 생성에 성공하면 이미지와 게시글을 저장한다")
     void createSavesPostAfterValidationWithImages() {
         User writer = user(1L, "writer@test.com");
@@ -152,6 +168,21 @@ class PostServiceImplTest {
         Throwable throwable = catchThrowable(() -> postService.update(2L, 10L, request));
 
         ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
+        assertThat(post.getContents()).isEqualTo("content");
+    }
+
+    @Test
+    @DisplayName("게시글 수정은 본문이 없으면 입력값 오류를 반환하고 내용은 유지된다")
+    void updateThrowsInvalidParameterWhenContentsMissing() {
+        User owner = user(1L, "owner@test.com");
+        Post post = post(10L, owner);
+        PostRequestDto.UpdatePostDto request = updateRequest(null);
+
+        when(postRepository.findById(10L)).thenReturn(Optional.of(post));
+
+        Throwable throwable = catchThrowable(() -> postService.update(1L, 10L, request));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PARAMETER_ERROR);
         assertThat(post.getContents()).isEqualTo("content");
     }
 

--- a/src/test/java/com/mogak/spring/web/controller/JogakControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/JogakControllerTest.java
@@ -67,7 +67,7 @@ class JogakControllerTest {
     @Test
     @DisplayName("조각 생성 요청이 성공하면 생성 응답 계약을 반환한다")
     void createJogakContract() throws Exception {
-        when(jogakService.createJogak(any(JogakRequestDto.CreateJogakDto.class))).thenReturn(JogakResponseDto.CreateJogakDto.builder()
+        when(jogakService.createJogak(eq(1L), any(JogakRequestDto.CreateJogakDto.class))).thenReturn(JogakResponseDto.CreateJogakDto.builder()
                 .jogakId(1L)
                 .mogakTitle("정보처리기사")
                 .category("자격증")
@@ -187,7 +187,7 @@ class JogakControllerTest {
     @Test
     @DisplayName("조각 시작 요청이 성공하면 성공 응답 계약을 반환한다")
     void startJogakContract() throws Exception {
-        when(jogakService.startJogak(1L)).thenReturn(JogakResponseDto.JogakDailyJogakDto.builder()
+        when(jogakService.startJogak(1L, 1L)).thenReturn(JogakResponseDto.JogakDailyJogakDto.builder()
                 .jogakId(1L)
                 .dailyJogakId(10L)
                 .title("문제풀이")
@@ -212,7 +212,7 @@ class JogakControllerTest {
     @Test
     @DisplayName("이미 시작한 조각의 시작을 요청하면 에러 응답 계약을 반환한다")
     void startJogakAlreadyStartedErrorContract() throws Exception {
-        when(jogakService.startJogak(1L)).thenThrow(new JogakException(ErrorCode.ALREADY_START_JOGAK));
+        when(jogakService.startJogak(1L, 1L)).thenThrow(new JogakException(ErrorCode.ALREADY_START_JOGAK));
 
         mockMvc.perform(post("/api/modarats/mogaks/jogaks/1/start"))
                 .andExpect(status().isConflict())
@@ -226,7 +226,7 @@ class JogakControllerTest {
     @Test
     @DisplayName("조각 성공 요청이 성공하면 성공 응답 계약을 반환한다")
     void successJogakContract() throws Exception {
-        when(jogakService.successJogak(10L)).thenReturn(JogakResponseDto.JogakDailyJogakDto.builder()
+        when(jogakService.successJogak(1L, 10L)).thenReturn(JogakResponseDto.JogakDailyJogakDto.builder()
                 .jogakId(1L)
                 .dailyJogakId(10L)
                 .title("문제풀이")
@@ -251,7 +251,7 @@ class JogakControllerTest {
     @Test
     @DisplayName("이미 종료한 조각의 성공을 요청하면 에러 응답 계약을 반환한다")
     void successJogakAlreadyEndedErrorContract() throws Exception {
-        when(jogakService.successJogak(10L)).thenThrow(new JogakException(ErrorCode.ALREADY_END_JOGAK));
+        when(jogakService.successJogak(1L, 10L)).thenThrow(new JogakException(ErrorCode.ALREADY_END_JOGAK));
 
         mockMvc.perform(put("/api/modarats/mogaks/jogaks/10/success"))
                 .andExpect(status().isConflict())
@@ -265,7 +265,7 @@ class JogakControllerTest {
     @Test
     @DisplayName("존재하지 않는 조각의 성공을 요청하면 에러 응답 계약을 반환한다")
     void successJogakNotFoundErrorContract() throws Exception {
-        when(jogakService.successJogak(999L)).thenThrow(new JogakException(ErrorCode.NOT_EXIST_JOGAK));
+        when(jogakService.successJogak(1L, 999L)).thenThrow(new JogakException(ErrorCode.NOT_EXIST_JOGAK));
 
         mockMvc.perform(put("/api/modarats/mogaks/jogaks/999/success"))
                 .andExpect(status().isNotFound())

--- a/src/test/java/com/mogak/spring/web/controller/ModaratControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/ModaratControllerTest.java
@@ -128,12 +128,7 @@ class ModaratControllerTest {
     void deleteModaratForwardsUserId() throws Exception {
         mockMvc.perform(delete("/api/modarats/10"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.time").exists())
-                .andExpect(jsonPath("$.status").value("OK"))
-                .andExpect(jsonPath("$.code").value("success"))
-                .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
-                .andExpect(jsonPath("$.result").doesNotExist());
+                .andExpect(content().string(""));
 
         verify(modaratService).delete(1L, 10L);
     }

--- a/src/test/java/com/mogak/spring/web/controller/ModaratControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/ModaratControllerTest.java
@@ -1,0 +1,140 @@
+package com.mogak.spring.web.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mogak.spring.domain.modarat.Modarat;
+import com.mogak.spring.domain.user.User;
+import com.mogak.spring.exception.GlobalExceptionHandler;
+import com.mogak.spring.jwt.JwtTokenProvider;
+import com.mogak.spring.repository.query.SingleDetailModaratDto;
+import com.mogak.spring.service.ModaratService;
+import com.mogak.spring.support.SecurityContextTestHelper;
+import com.mogak.spring.support.TestFixtureFactory;
+import com.mogak.spring.web.dto.modaratdto.ModaratRequestDto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Import(GlobalExceptionHandler.class)
+@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(ModaratController.class)
+@ActiveProfiles("test")
+class ModaratControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @MockitoBean
+    private ModaratService modaratService;
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextTestHelper.setAuthentication("user@test.com");
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextTestHelper.clear();
+    }
+
+    @Test
+    @DisplayName("모다라트 생성 요청이 성공하면 생성 응답 계약을 반환한다")
+    void createModaratContract() throws Exception {
+        User user = TestFixtureFactory.user(1L, "user@test.com", "tester", TestFixtureFactory.job("개발"), TestFixtureFactory.address("서울"));
+        Modarat modarat = TestFixtureFactory.modarat(10L, user, "메인 모다라트", "#112233");
+        when(modaratService.create(anyLong(), any(ModaratRequestDto.CreateModaratDto.class))).thenReturn(modarat);
+        ModaratRequestDto.CreateModaratDto request = new ModaratRequestDto.CreateModaratDto();
+        org.springframework.test.util.ReflectionTestUtils.setField(request, "title", "메인 모다라트");
+        org.springframework.test.util.ReflectionTestUtils.setField(request, "color", "#112233");
+
+        mockMvc.perform(post("/api/modarats")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.time").exists())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.code").value("success"))
+                .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
+                .andExpect(jsonPath("$.result.id").value(10L))
+                .andExpect(jsonPath("$.result.title").value("메인 모다라트"));
+
+        verify(modaratService).create(eq(1L), any(ModaratRequestDto.CreateModaratDto.class));
+    }
+
+    @Test
+    @DisplayName("모다라트 상세 조회 요청이 성공하면 userId를 서비스로 전달한다")
+    void getDetailModaratForwardsUserId() throws Exception {
+        when(modaratService.getDetailModarat(eq(1L), eq(10L))).thenReturn(new SingleDetailModaratDto(10L, "메인 모다라트", "#112233"));
+
+        mockMvc.perform(get("/api/modarats/10"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.result.id").value(10L))
+                .andExpect(jsonPath("$.result.title").value("메인 모다라트"));
+
+        verify(modaratService).getDetailModarat(1L, 10L);
+    }
+
+    @Test
+    @DisplayName("모다라트 수정 요청이 성공하면 userId를 서비스로 전달한다")
+    void updateModaratForwardsUserId() throws Exception {
+        User user = TestFixtureFactory.user(1L, "user@test.com", "tester", TestFixtureFactory.job("개발"), TestFixtureFactory.address("서울"));
+        Modarat modarat = TestFixtureFactory.modarat(10L, user, "수정된 모다라트", "#445566");
+        when(modaratService.update(eq(1L), eq(10L), any(ModaratRequestDto.UpdateModaratDto.class))).thenReturn(modarat);
+        ModaratRequestDto.UpdateModaratDto request = new ModaratRequestDto.UpdateModaratDto();
+        org.springframework.test.util.ReflectionTestUtils.setField(request, "title", "수정된 모다라트");
+        org.springframework.test.util.ReflectionTestUtils.setField(request, "color", "#445566");
+
+        mockMvc.perform(put("/api/modarats/10")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.id").value(10L))
+                .andExpect(jsonPath("$.result.title").value("수정된 모다라트"));
+
+        verify(modaratService).update(eq(1L), eq(10L), any(ModaratRequestDto.UpdateModaratDto.class));
+    }
+
+    @Test
+    @DisplayName("모다라트 삭제 요청이 성공하면 userId를 서비스로 전달한다")
+    void deleteModaratForwardsUserId() throws Exception {
+        mockMvc.perform(delete("/api/modarats/10"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.time").exists())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.code").value("success"))
+                .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
+                .andExpect(jsonPath("$.result").doesNotExist());
+
+        verify(modaratService).delete(1L, 10L);
+    }
+}

--- a/src/test/java/com/mogak/spring/web/controller/MogakControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/MogakControllerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -97,6 +98,8 @@ class MogakControllerTest {
                 .andExpect(jsonPath("$.result.id").value(1L))
                 .andExpect(jsonPath("$.result.title").value("정보처리기사"))
                 .andExpect(jsonPath("$.result.smallCategory").value("필기"));
+
+        verify(mogakService).create(eq(1L), any(MogakRequestDto.CreateDto.class));
     }
 
     @Test
@@ -136,6 +139,8 @@ class MogakControllerTest {
                 .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
                 .andExpect(jsonPath("$.result.size").value(1))
                 .andExpect(jsonPath("$.result.mogaks[0].title").value("정보처리기사"));
+
+        verify(mogakService).getMogakDtoList(1L, 10L);
     }
 
     @Test
@@ -164,6 +169,8 @@ class MogakControllerTest {
                 .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
                 .andExpect(jsonPath("$.result[0].jogakId").value(100L))
                 .andExpect(jsonPath("$.result[0].isAlreadyAdded").value(true));
+
+        verify(mogakService).getJogaks(1L, 1L, LocalDate.of(2026, 3, 26));
     }
 
     @Test
@@ -177,13 +184,41 @@ class MogakControllerTest {
                 .andExpect(jsonPath("$.code").value("success"))
                 .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
                 .andExpect(jsonPath("$.result").doesNotExist());
+
+        verify(mogakService).deleteMogak(1L, 1L);
+    }
+
+    @Test
+    @DisplayName("모각 수정 요청이 성공하면 userId를 서비스로 전달한다")
+    void updateMogakForwardsUserId() throws Exception {
+        when(mogakService.updateMogak(eq(1L), any(MogakRequestDto.UpdateDto.class))).thenReturn(MogakResponseDto.GetMogakDto.builder()
+                .id(1L)
+                .title("수정된 모각")
+                .bigCategory(MogakCategory.builder().id(1).name("자격증").build())
+                .smallCategory("필기")
+                .color("#112233")
+                .build());
+
+        mockMvc.perform(put("/api/modarats/mogaks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(MogakRequestDto.UpdateDto.builder()
+                                .mogakId(1L)
+                                .title("수정된 모각")
+                                .bigCategory("자격증")
+                                .smallCategory("필기")
+                                .color("#112233")
+                                .build())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.title").value("수정된 모각"));
+
+        verify(mogakService).updateMogak(eq(1L), any(MogakRequestDto.UpdateDto.class));
     }
 
     @Test
     @DisplayName("존재하지 않는 모각 삭제를 요청하면 에러 응답 계약을 반환한다")
     void deleteMogakNotFoundContract() throws Exception {
         doThrow(new MogakException(ErrorCode.NOT_EXIST_MOGAK))
-                .when(mogakService).deleteMogak(99L);
+                .when(mogakService).deleteMogak(1L, 99L);
 
         mockMvc.perform(delete("/api/modarats/mogaks/99"))
                 .andExpect(status().isNotFound())

--- a/src/test/java/com/mogak/spring/web/controller/PostControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/PostControllerTest.java
@@ -1,32 +1,52 @@
 package com.mogak.spring.web.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mogak.spring.domain.mogak.Mogak;
+import com.mogak.spring.domain.post.Post;
+import com.mogak.spring.domain.post.PostImg;
+import com.mogak.spring.exception.AuthException;
 import com.mogak.spring.exception.GlobalExceptionHandler;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.jwt.JwtTokenProvider;
-import com.mogak.spring.domain.post.Post;
 import com.mogak.spring.service.PostService;
 import com.mogak.spring.service.StorageService;
 import com.mogak.spring.support.SecurityContextTestHelper;
-import org.junit.jupiter.api.DisplayName;
+import com.mogak.spring.support.TestFixtureFactory;
+import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
+import com.mogak.spring.web.dto.postdto.PostRequestDto;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -57,14 +77,62 @@ class PostControllerTest {
     }
 
     @Test
-    @DisplayName("이미지 포함 게시글 생성 요청은 storage 비활성 상태에서 503 에러 응답 계약을 반환한다")
-    void createPostStorageDisabledContract() throws Exception {
-        SecurityContextTestHelper.setAuthentication("writer@test.com");
+    @DisplayName("게시글 생성은 preflight 후 storage 업로드, 생성 순서로 처리된다")
+    void createPostValidatesBeforeUploadAndCreate() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
+        PostRequestDto.CreatePostDto request = createRequest("content");
         MockMultipartFile requestPart = new MockMultipartFile(
                 "request",
                 "",
                 MediaType.APPLICATION_JSON_VALUE,
-                objectMapper.writeValueAsBytes(new com.mogak.spring.web.dto.postdto.PostRequestDto.CreatePostDto())
+                objectMapper.writeValueAsBytes(request)
+        );
+        MockMultipartFile image = new MockMultipartFile(
+                "multipartFile",
+                "post.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "png".getBytes()
+        );
+        List<PostImgRequestDto.CreatePostImgDto> uploadedImages = List.of(
+                PostImgRequestDto.CreatePostImgDto.builder()
+                        .imgName("post.png")
+                        .imgUrl("https://example.com/post.png")
+                        .thumbnail(true)
+                        .build()
+        );
+        Post post = createPost(1L, 7L, 1L, "content", uploadedImages.get(0).getImgUrl());
+
+        doNothing().when(postService).validateCreateAccess(eq(7L), any(), anyList(), eq(1L));
+        when(storageService.uploadImg(any(), any())).thenReturn(uploadedImages);
+        when(postService.create(eq(7L), any(), eq(uploadedImages), eq(1L))).thenReturn(post);
+
+                mockMvc.perform(multipart("/api/mogaks/{mogakId}/posts", 1L)
+                        .file(requestPart)
+                        .file(image)
+                        .with(mockRequest -> {
+                            mockRequest.setMethod("POST");
+                            return mockRequest;
+                        }))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.id").value(1))
+                .andExpect(jsonPath("$.result.userId").value(7));
+
+        InOrder inOrder = inOrder(postService, storageService);
+        inOrder.verify(postService).validateCreateAccess(eq(7L), any(), anyList(), eq(1L));
+        inOrder.verify(storageService).uploadImg(any(), any());
+        inOrder.verify(postService).create(eq(7L), any(), eq(uploadedImages), eq(1L));
+    }
+
+    @Test
+    @DisplayName("게시글 생성 preflight가 실패하면 storage 업로드는 호출되지 않는다")
+    void createPostPreflightFailureDoesNotUpload() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
+        PostRequestDto.CreatePostDto request = createRequest("content");
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
         );
         MockMultipartFile image = new MockMultipartFile(
                 "multipartFile",
@@ -73,44 +141,148 @@ class PostControllerTest {
                 "png".getBytes()
         );
 
-        doThrow(new com.mogak.spring.exception.BaseException(ErrorCode.STORAGE_DISABLED))
-                .when(storageService).uploadImg(any(), any());
+        doThrow(new AuthException(ErrorCode.INVALID_PERMISSION))
+                .when(postService)
+                .validateCreateAccess(eq(7L), any(), anyList(), eq(1L));
 
         mockMvc.perform(multipart("/api/mogaks/{mogakId}/posts", 1L)
                         .file(requestPart)
                         .file(image)
-                        .with(request -> {
-                            request.setMethod("POST");
-                            return request;
+                        .with(mockRequest -> {
+                            mockRequest.setMethod("POST");
+                            return mockRequest;
                         }))
-                .andExpect(status().isServiceUnavailable())
+                .andExpect(status().isForbidden())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.time").exists())
-                .andExpect(jsonPath("$.status").value("SERVICE_UNAVAILABLE"))
-                .andExpect(jsonPath("$.code").value("Z006"))
-                .andExpect(jsonPath("$.message").value("스토리지 기능이 비활성화되어 있습니다"));
+                .andExpect(jsonPath("$.code").value("T004"));
+
+        verify(storageService, never()).uploadImg(any(), any());
+        verify(postService, never()).create(any(), any(), anyList(), any());
     }
 
     @Test
-    @DisplayName("게시글 삭제 요청은 storage 비활성 상태에서 503 에러 응답 계약을 반환한다")
-    void deletePostStorageDisabledContract() throws Exception {
-        when(postService.findById(1L)).thenReturn(Post.builder()
-                .id(1L)
-                .contents("content")
-                .postThumbnailUrl("thumbnail")
-                .validation("VALID")
-                .viewCnt(0)
-                .build());
-        when(postService.findAllImgByPost(any())).thenReturn(java.util.List.of());
-        doThrow(new com.mogak.spring.exception.BaseException(ErrorCode.STORAGE_DISABLED))
-                .when(storageService).deleteImg(any(), any());
+    @DisplayName("모각별 게시글 조회는 인증 사용자의 id를 서비스에 전달한다")
+    void getPostListUsesAuthenticatedUserId() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
+        Slice<Post> posts = new SliceImpl<>(List.of());
+        when(postService.getAllPosts(7L, 0, 1L, 10)).thenReturn(posts);
+
+        mockMvc.perform(get("/api/mogaks/{mogakId}/posts", 1L)
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk());
+
+        verify(postService).getAllPosts(7L, 0, 1L, 10);
+    }
+
+    @Test
+    @DisplayName("게시글 상세 조회는 인증 사용자의 id를 서비스에 전달한다")
+    void getPostDetailUsesAuthenticatedUserId() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
+        Post post = createPost(1L, 7L, 1L, "content", "https://example.com/post.png");
+        when(postService.findById(7L, 1L)).thenReturn(post);
+        when(postService.findNotThumbnailImg(post)).thenReturn(List.of("https://example.com/post-2.png"));
+
+        mockMvc.perform(get("/api/mogaks/posts/{postId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.postId").value(1));
+
+        verify(postService).findById(7L, 1L);
+    }
+
+    @Test
+    @DisplayName("게시글 수정은 인증 사용자의 id를 서비스에 전달한다")
+    void updatePostUsesAuthenticatedUserId() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
+        PostRequestDto.UpdatePostDto request = updateRequest("updated");
+        Post post = createPost(1L, 7L, 1L, "updated", "https://example.com/post.png");
+        when(postService.update(eq(7L), eq(1L), any())).thenReturn(post);
+
+        mockMvc.perform(put("/api/mogaks/posts/{postId}", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.id").value(1));
+
+        verify(postService).update(eq(7L), eq(1L), any());
+    }
+
+    @Test
+    @DisplayName("게시글 삭제는 owner 검증 후 storage 삭제와 db 삭제를 순서대로 호출한다")
+    void deletePostValidatesBeforeStorageDeleteAndDelete() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
+        Post post = createPost(1L, 7L, 1L, "content", "https://example.com/post.png");
+        PostImg postImg = PostImg.builder()
+                .id(11L)
+                .post(post)
+                .imgName("post.png")
+                .imgUrl("https://example.com/post.png")
+                .build();
+
+        when(postService.findById(7L, 1L)).thenReturn(post);
+        when(postService.findAllImgByPost(post)).thenReturn(List.of(postImg));
+        doNothing().when(storageService).deleteImg(any(), any());
+        doNothing().when(postService).delete(7L, 1L);
 
         mockMvc.perform(delete("/api/mogaks/posts/{postId}", 1L))
-                .andExpect(status().isServiceUnavailable())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.validation").value("INACTIVE"));
+
+        InOrder inOrder = inOrder(postService, storageService);
+        inOrder.verify(postService).findById(7L, 1L);
+        inOrder.verify(postService).findAllImgByPost(post);
+        inOrder.verify(storageService).deleteImg(any(), any());
+        inOrder.verify(postService).delete(7L, 1L);
+    }
+
+    @Test
+    @DisplayName("게시글 삭제 owner 검증이 실패하면 storage 삭제는 호출되지 않는다")
+    void deletePostOwnerFailureDoesNotCallStorage() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
+        doThrow(new AuthException(ErrorCode.INVALID_PERMISSION))
+                .when(postService)
+                .findById(7L, 1L);
+
+        mockMvc.perform(delete("/api/mogaks/posts/{postId}", 1L))
+                .andExpect(status().isForbidden())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.time").exists())
-                .andExpect(jsonPath("$.status").value("SERVICE_UNAVAILABLE"))
-                .andExpect(jsonPath("$.code").value("Z006"))
-                .andExpect(jsonPath("$.message").value("스토리지 기능이 비활성화되어 있습니다"));
+                .andExpect(jsonPath("$.code").value("T004"));
+
+        verify(storageService, never()).deleteImg(any(), any());
+        verify(postService, never()).delete(any(), any());
+    }
+
+    private PostRequestDto.CreatePostDto createRequest(String contents) {
+        PostRequestDto.CreatePostDto request = new PostRequestDto.CreatePostDto();
+        ReflectionTestUtils.setField(request, "contents", contents);
+        return request;
+    }
+
+    private PostRequestDto.UpdatePostDto updateRequest(String contents) {
+        PostRequestDto.UpdatePostDto request = new PostRequestDto.UpdatePostDto();
+        ReflectionTestUtils.setField(request, "contents", contents);
+        return request;
+    }
+
+    private Post createPost(Long postId, Long userId, Long mogakId, String contents, String thumbnailUrl) {
+        var writer = TestFixtureFactory.user(userId, "writer@test.com", "writer", null, null);
+        Mogak mogak = TestFixtureFactory.mogak(
+                mogakId,
+                writer,
+                TestFixtureFactory.modarat(1L, writer, "modarat", "#000000"),
+                TestFixtureFactory.category(1, "자격증"),
+                "mogak",
+                "#112233"
+        );
+        Post post = Post.builder()
+                .id(postId)
+                .mogak(mogak)
+                .user(writer)
+                .contents(contents)
+                .postThumbnailUrl(thumbnailUrl)
+                .validation("ACTIVE")
+                .viewCnt(0)
+                .build();
+        return post;
     }
 }


### PR DESCRIPTION
## Summary

- 모다라트/모각/조각 API에 owner-only 권한 검증을 적용했습니다.
- 개인 post API에 owner-only 권한 검증을 적용했습니다.
- post 생성 시 storage 업로드 전에 권한과 기본 입력을 먼저 검증하도록 변경했습니다.
- cascade 삭제는 부모 권한 검증 이후 내부 cascade 메서드로 조합하도록 정리했습니다.
- DailyJogak success/fail 처리는 owner 검증과 응답 변환에 필요한 fetch graph만 사용하도록 좁혔습니다.

## Details

### Core Resource Access

- 모다라트 상세/수정/삭제는 요청 사용자와 owner가 다르면 `INVALID_PERMISSION`을 반환합니다.
- 모각 생성/목록/조각 목록/수정/삭제는 부모 또는 대상 리소스 owner를 먼저 검증합니다.
- 조각 생성/상세/수정/삭제/시작/성공/실패는 대상 조각 또는 DailyJogak의 owner를 검증합니다.
- 없는 리소스는 기존 not-exist 예외를 유지하고, 타인 리소스는 `403 INVALID_PERMISSION`으로 분리했습니다.
- 서비스 경계에서도 `null` requester가 owner 검증을 우회하지 못하도록 owner 비교를 통일했습니다.

### Post Access

- `/api/mogaks/{mogakId}/posts` 개인 목록 조회는 모각 owner만 접근할 수 있습니다.
- `/api/mogaks/posts/{postId}` 상세/수정/삭제는 post owner만 접근할 수 있습니다.
- post 생성은 storage 업로드 전에 `validateCreateAccess`를 수행합니다.
- post 삭제는 owner 검증 후 storage 삭제와 DB 삭제를 수행하므로, 권한 실패 시 storage 삭제가 호출되지 않습니다.

### Cascade

- `deleteMogakCascadeAfterParentAuthorization`
- `deleteJogakCascadeAfterParentAuthorization`

상위 리소스에서 owner 검증이 완료된 뒤 내부 cascade 삭제용으로 사용합니다.

### DailyJogak Graph

- `successJogak` / `failJogak`에서 DailyJogak을 조회할 때 필요한 graph만 fetch합니다.
- 유지한 fetch:
  - `DailyJogak -> Jogak`
  - `Jogak -> User`
  - `Jogak -> Mogak`
  - `Jogak -> Category`
- 제거한 fetch:
  - `DailyJogak -> Mogak`
  - `DailyJogak -> Category`

## Deferred / Out of Scope

- 네트워크 피드 정책은 아직 확정되지 않아 변경하지 않았습니다.
- 댓글 읽기/작성, 좋아요 정책은 이번 범위에서 변경하지 않았습니다.
- storage 업로드 성공 후 DB 저장 실패, storage 삭제 성공 후 DB 삭제 실패에 대한 보상 처리는 별도 리팩토링 범위로 남겼습니다.
- orchestration 구조 개선은 추후 리팩토링 이슈로 분리할 수 있습니다.


## 관련 이슈
#144 