### PR TITLE
refactor(#146): address immediate Java 25 review findings

### DIFF
--- a/src/main/java/com/mogak/spring/converter/PostConverter.java
+++ b/src/main/java/com/mogak/spring/converter/PostConverter.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Slice;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class PostConverter {
@@ -100,7 +101,7 @@ public class PostConverter {
                 .userJob(post.getUser().getJob().getName())
                 .contents(post.getContents())
                 .imgUrls(post.getPostImgs().stream()
-                        .filter(img -> img.getImgUrl() != post.getPostThumbnailUrl())
+                        .filter(img -> !Objects.equals(img.getImgUrl(), post.getPostThumbnailUrl()))
                         .map(PostImg::getImgUrl)
                         .collect(Collectors.toList()))
                 .commentCnt(post.getCommentCnt())

--- a/src/main/java/com/mogak/spring/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mogak/spring/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.mogak.spring.exception;
 
 import com.mogak.spring.global.BaseException;
 import com.mogak.spring.global.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -13,11 +14,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.util.Objects;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ErrorResponse> BaseException(BaseException e) {
-        e.printStackTrace();
+        if (e.getHttpStatus().is5xxServerError()) {
+            log.error("BaseException occurred: code={}, message={}", e.getCode(), e.getMessage(), e);
+        } else {
+            log.warn("BaseException occurred: code={}, message={}", e.getCode(), e.getMessage());
+        }
         ErrorCode errorCode = ErrorCode.findByMessage(e.getMessage());
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ErrorResponse.of(Objects.requireNonNull(errorCode)));
@@ -44,9 +50,19 @@ public class GlobalExceptionHandler {
     /**
      * 잘못 입력된 경우
      * */
-    @ExceptionHandler({NullPointerException.class, HttpMessageNotReadableException.class})
-    public ResponseEntity<ErrorResponse> handleBadRequestException(NullPointerException e) {
-        e.printStackTrace();
+    @ExceptionHandler(NullPointerException.class)
+    public ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException e) {
+        log.warn("NullPointerException occurred: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.of(ErrorCode.BAD_REQUEST));
+    }
+
+    /**
+     * 잘못 입력된 경우
+     * */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.warn("HttpMessageNotReadableException occurred: {}", e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(ErrorCode.BAD_REQUEST));
     }
@@ -56,7 +72,7 @@ public class GlobalExceptionHandler {
      * */
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorResponse> handleAnyException(RuntimeException e) {
-        e.printStackTrace();
+        log.error("Unexpected runtime exception occurred: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR));
     }

--- a/src/main/java/com/mogak/spring/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mogak/spring/exception/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BaseException.class)
-    public ResponseEntity<ErrorResponse> BaseException(BaseException e) {
+    public ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
         if (e.getHttpStatus().is5xxServerError()) {
             log.error("BaseException occurred: code={}, message={}", e.getCode(), e.getMessage(), e);
         } else {

--- a/src/main/java/com/mogak/spring/scheduler/Scheduler.java
+++ b/src/main/java/com/mogak/spring/scheduler/Scheduler.java
@@ -1,15 +1,15 @@
 package com.mogak.spring.scheduler;
 
 import com.mogak.spring.service.JogakService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class Scheduler {
 
-    @Autowired
-    private JogakService jogakService;
+    private final JogakService jogakService;
 
     @Scheduled(zone = "Asia/Seoul", cron = "1 0 0 * * *")
     public void createRoutineJogakByScheduler() {

--- a/src/main/java/com/mogak/spring/service/PostServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/PostServiceImpl.java
@@ -123,7 +123,7 @@ public class PostServiceImpl implements PostService {
         return posts.stream()
                 .map(p -> {
                     List<String> imgUrls = p.getPostImgs().stream()
-                            .filter(img -> img.getImgUrl() != p.getPostThumbnailUrl())
+                            .filter(img -> !Objects.equals(img.getImgUrl(), p.getPostThumbnailUrl()))
                             .map(PostImg::getImgUrl)
                             .collect(Collectors.toList());
                     NetworkPostDto dto = NetworkPostDto.builder()

--- a/src/test/java/com/mogak/spring/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/mogak/spring/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,101 @@
+package com.mogak.spring.exception;
+
+import com.mogak.spring.global.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+class GlobalExceptionHandlerTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = standaloneSetup(new ExceptionTestController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+
+    @Test
+    @DisplayName("BaseException은 매핑된 에러 코드 상태코드와 함께 반환한다")
+    void shouldReturnMappedErrorCodeForBaseException() throws Exception {
+        mockMvc.perform(get("/global-exceptions/base"))
+                .andExpect(status().is(NOT_FOUND.value()))
+                .andExpect(jsonPath("$.status").value(ErrorCode.NOT_EXIST_USER.getStatus().name()))
+                .andExpect(jsonPath("$.code").value(ErrorCode.NOT_EXIST_USER.getCode()))
+                .andExpect(jsonPath("$.message").value(ErrorCode.NOT_EXIST_USER.getMessage()));
+    }
+
+    @Test
+    @DisplayName("NullPointerException은 BAD_REQUEST로 매핑된다")
+    void shouldReturnBadRequestForNullPointerException() throws Exception {
+        mockMvc.perform(get("/global-exceptions/null-pointer"))
+                .andExpect(status().is(BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.status").value(ErrorCode.BAD_REQUEST.getStatus().name()))
+                .andExpect(jsonPath("$.code").value(ErrorCode.BAD_REQUEST.getCode()));
+    }
+
+    @Test
+    @DisplayName("잘못된 JSON 바디는 HttpMessageNotReadableException으로 BAD_REQUEST를 반환한다")
+    void shouldReturnBadRequestForMessageNotReadableException() throws Exception {
+        mockMvc.perform(post("/global-exceptions/request")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":}"))
+                .andExpect(status().is(BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.status").value(ErrorCode.BAD_REQUEST.getStatus().name()))
+                .andExpect(jsonPath("$.code").value(ErrorCode.BAD_REQUEST.getCode()));
+    }
+
+    @Test
+    @DisplayName("RuntimeException은 INTERNAL_SERVER_ERROR로 매핑된다")
+    void shouldReturnInternalServerErrorForUnexpectedRuntimeException() throws Exception {
+        mockMvc.perform(get("/global-exceptions/runtime"))
+                .andExpect(status().is(INTERNAL_SERVER_ERROR.value()))
+                .andExpect(jsonPath("$.status").value(ErrorCode.INTERNAL_SERVER_ERROR.getStatus().name()))
+                .andExpect(jsonPath("$.code").value(ErrorCode.INTERNAL_SERVER_ERROR.getCode()));
+    }
+
+    @RestController
+    static class ExceptionTestController {
+
+        @GetMapping("/global-exceptions/base")
+        public void throwBaseException() {
+            throw new BaseException(ErrorCode.NOT_EXIST_USER);
+        }
+
+        @GetMapping("/global-exceptions/null-pointer")
+        public void throwNullPointerException() {
+            throw new NullPointerException("npe");
+        }
+
+        @GetMapping("/global-exceptions/runtime")
+        public void throwRuntimeException() {
+            throw new IllegalStateException("unexpected");
+        }
+
+        @PostMapping("/global-exceptions/request")
+        public void receiveRequest(@RequestBody TestRequest request) {
+            // Intentionally left blank
+        }
+    }
+
+    record TestRequest(String name) {
+    }
+}


### PR DESCRIPTION
## 해결하려던 문제 혹은 구현하려는 기능
이슈 #146의 즉시 수정 권장 항목 중 작은 결함 수정 범위를 처리했습니다.

  - 게시글 이미지 URL 비교 로직을 참조 비교(`!=`)에서 값 비교(`Objects.equals`)로 변경
  - `Scheduler`의 필드 주입을 생성자 주입으로 변경
  - `GlobalExceptionHandler`의 `NullPointerException` / `HttpMessageNotReadableException` 핸들러를 분리
  - `printStackTrace()`를 `log.warn/error` 기반 로깅으로 교체
  - 전역 예외 핸들러 회귀 테스트 추가

  ## 변경 상세

  ### 게시글 이미지 URL 비교 수정

  `PostConverter`, `PostServiceImpl`에서 썸네일 이미지를 제외할 때 `String` 참조 비교를 사용하던 부분을
  값 비교로 수정했습니다.

  기존 로직은 같은 URL 문자열이어도 서로 다른 `String` 인스턴스면 썸네일이 제외되지 않을 수 있었습니다.

  ### Scheduler 생성자 주입 전환

  `@Autowired` 필드 주입을 제거하고 `@RequiredArgsConstructor` 기반 생성자 주입으로 변경했습니다.

  ### GlobalExceptionHandler 개선

  기존에는 `NullPointerException`과 `HttpMessageNotReadableException`을 하나의 핸들러에서 처리하면서 메
  서드 파라미터 타입이 `NullPointerException`으로 고정되어 있었습니다.

  이를 각각의 핸들러로 분리해 잘못된 JSON body 요청도 안정적으로 `BAD_REQUEST` 응답을 반환하도록 했습니
  다.

  또한 `printStackTrace()`를 제거하고 예외 성격에 따라 `warn` / `error` 로그를 남기도록 변경했습니다.
## 관련 이슈
#146
