### PR TITLE
refactor(#140): Refine ERD deletion lifecycle

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@
 - [Claude Compatibility](../CLAUDE.md)
 - [프로젝트 규약](operations/policies/PROJECT_CONVENTIONS.md)
 - [스택 마이그레이션 가이드](operations/policies/STACK_MIGRATION_GUIDE.md)
+- [ERD 및 삭제 라이프사이클](operations/policies/ERD_DECISIONS_AND_LIFECYCLE.md)
 - [외부 리뷰 워크플로우](operations/policies/EXTERNAL_REVIEW_WORKFLOW.md)
 - [도메인 문서 레지스트리](operations/policies/DOMAIN_DOCUMENT_REGISTRY.md)
 - [가이던스 스키마](operations/policies/guidance-schema.md)

--- a/docs/operations/policies/DOMAIN_DOCUMENT_REGISTRY.md
+++ b/docs/operations/policies/DOMAIN_DOCUMENT_REGISTRY.md
@@ -21,6 +21,7 @@
 | scheduler | `PROJECT_CONVENTIONS.md`, `.codex/rules/testing.md`, `.codex/workflows/full-delivery.md` | yes |
 | storage | `PROJECT_CONVENTIONS.md`, `.codex/rules/persistence.md`, `.codex/workflows/full-delivery.md` | yes |
 | persistence | `PROJECT_CONVENTIONS.md`, `.codex/rules/persistence.md`, `EXTERNAL_REVIEW_WORKFLOW.md` | no |
+| data-lifecycle | `PROJECT_CONVENTIONS.md`, `ERD_DECISIONS_AND_LIFECYCLE.md`, `EXTERNAL_REVIEW_WORKFLOW.md` | yes |
 | platform-common | `PROJECT_CONVENTIONS.md`, `STACK_MIGRATION_GUIDE.md`, `.codex/rules/spring-core.md`, `.codex/workflows/refactor-guarded.md` | no |
 
 ## Consult Triggers

--- a/docs/operations/policies/ERD_DECISIONS_AND_LIFECYCLE.md
+++ b/docs/operations/policies/ERD_DECISIONS_AND_LIFECYCLE.md
@@ -1,0 +1,47 @@
+# ERD Decisions and Lifecycle
+
+이 문서는 `MOGAK_Spring`의 공개 ERD 판단 기준과 엔티티 삭제/보존 정책을 정리한다.
+
+## Scope
+- 이 문서는 공개 가능한 구조 결정만 담는다.
+- 비공개 정책의 제목, 본문, 예시 판단 기준은 적지 않는다.
+- `AgreeUser` 및 withdrawn user 처리처럼 정책 확정이 남은 항목은 pending으로 표기한다.
+
+## ERD Decisions
+- `AgreeUser`는 실제 terms consent 모델로 유지한다.
+- `DailyJogak`는 `Jogak`에서 파생되는 날짜 단위 인스턴스로 본다.
+- `DailyJogak.title`과 `DailyJogak.isRoutine`은 생성 시점 스냅샷으로 취급한다.
+- 미래 일정은 `Jogak` + `JogakPeriod` 조합으로 계산하고, 미래 일정 표현용 `DailyJogak` row는 만들지 않는다.
+
+## Deletion Lifecycle
+
+| Entity | Lifecycle | Public note |
+| --- | --- | --- |
+| `User` | soft delete | withdrawn user의 email, nickname, profile anonymization 정책은 pending이다. |
+| `Modarat` | soft delete | 관련 삭제는 소프트 삭제 기준을 따른다. |
+| `Mogak` | soft delete | 관련 삭제는 소프트 삭제 기준을 따른다. |
+| `Jogak` | soft delete | 관련 삭제는 소프트 삭제 기준을 따른다. |
+| `DailyJogak` | soft delete | 날짜 인스턴스 이력을 보존한다. |
+| `Post` | soft delete | 게시물 삭제는 소프트 삭제 기준을 따른다. |
+| `PostComment` | soft delete | 댓글 삭제는 소프트 삭제 기준을 따른다. |
+| `JogakPeriod` | hard delete | 주기 정보는 하드 삭제한다. |
+| `PostLike` | hard delete | 좋아요 관계는 하드 삭제한다. |
+| `PostImg` | hard delete | 이미지 관계는 하드 삭제한다. |
+| `Follow` | hard delete | 팔로우 관계는 하드 삭제한다. |
+| `BlockUser` | hard delete | 차단 관계는 하드 삭제한다. |
+| `Report` | preserve | 신고 데이터는 보존한다. |
+| `AgreeUser` | pending | 실제 terms consent 모델로 유지하며, retention/anonymization/deletion policy는 pending이다. |
+
+## DailyJogak Creation Rules
+- routine midnight batch는 오늘자 `DailyJogak` row를 생성한다.
+- one-time schedule은 시작 시점에 `DailyJogak` row를 생성한다.
+- future schedule은 `DailyJogak` row 없이 `Jogak` + `JogakPeriod`로 계산한다.
+- 기존 `DailyJogak` row의 `title`과 `isRoutine`은 생성 시점 값을 유지한다.
+
+## Pending Items
+- `AgreeUser` retention policy
+- `AgreeUser` anonymization policy
+- `AgreeUser` deletion policy
+- withdrawn user email anonymization policy
+- withdrawn user nickname anonymization policy
+- withdrawn user profile anonymization policy

--- a/src/main/java/com/mogak/spring/domain/post/PostComment.java
+++ b/src/main/java/com/mogak/spring/domain/post/PostComment.java
@@ -20,7 +20,7 @@ public class PostComment extends SoftDeletableEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="post_id")
     private Post post;
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id")
     private User user;
     @Column(nullable = false)

--- a/src/main/java/com/mogak/spring/repository/PostLikeRepository.java
+++ b/src/main/java/com/mogak/spring/repository/PostLikeRepository.java
@@ -16,6 +16,10 @@ public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     Optional<PostLike> findByPostAndUser(Post post, User user);
     void deleteByPostAndUser(Post post, User user);
 
+    @Modifying
+    @Query("delete from PostLike pl where pl.post = :post")
+    void deleteAllByPost(@Param("post") Post post);
+
     @Query("select pl from PostLike pl join pl.post p join p.user pu " +
             "where pl.user.id = :userId and pu.id <> :userId and p.deletedAt is null and pu.deletedAt is null")
     List<PostLike> findActiveAllByUserIdOnOtherUserPosts(@Param("userId") Long userId);

--- a/src/main/java/com/mogak/spring/service/JogakServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/JogakServiceImpl.java
@@ -44,6 +44,7 @@ public class JogakServiceImpl implements JogakService {
     private final PeriodRepository periodRepository;
     private final DailyJogakRepository dailyJogakRepository;
     private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
     private final PostCommentRepository postCommentRepository;
     private final PostImgRepository postImgRepository;
     private final StorageCleanupService storageCleanupService;
@@ -153,14 +154,6 @@ public class JogakServiceImpl implements JogakService {
 
         validatePeriod(Optional.ofNullable(updateJogakDto.getIsRoutine()), Optional.ofNullable(updateJogakDto.getDays()));
         jogak.update(updateJogakDto.getTitle(), updateJogakDto.getIsRoutine(), updateJogakDto.getEndDate());
-
-        List<DailyJogak> dailyJogaks = dailyJogakRepository.findActiveAllByJogak(jogak);
-
-        if (!dailyJogaks.isEmpty()) {
-            for (DailyJogak dailyJogak : dailyJogaks) {
-                dailyJogak.updateJogak(jogak);
-            }
-        }
 
         if (updateJogakDto.getDays() != null) {
             updateJogakPeriod(jogak, updateJogakDto.getDays());
@@ -436,6 +429,7 @@ public class JogakServiceImpl implements JogakService {
     private void deletePostCascade(DailyJogak dailyJogak) {
         postRepository.findActiveAllByDailyJogakId(dailyJogak.getId())
                 .forEach(post -> {
+                    postLikeRepository.deleteAllByPost(post);
                     postCommentRepository.findActiveAllByPostForCleanup(post).forEach(comment -> {
                         comment.delete();
                         post.subtractCommentCnt();

--- a/src/main/java/com/mogak/spring/service/PostServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/PostServiceImpl.java
@@ -47,6 +47,7 @@ public class PostServiceImpl implements PostService {
     private final DailyJogakRepository dailyJogakRepository;
     private final UserRepository userRepository;
     private final PostImgRepository postImgRepository;
+    private final PostLikeRepository postLikeRepository;
     private final PostCommentRepository postCommentRepository;
     private final StorageCleanupService storageCleanupService;
     private static final String DIR_NAME = "img";
@@ -149,6 +150,7 @@ public class PostServiceImpl implements PostService {
     @Override
     public void delete(Long userId, Long postId) {
         Post post = getOwnedPost(userId, postId);
+        postLikeRepository.deleteAllByPost(post);
         List<PostImg> postImgList = postImgRepository.findAllByPost(post);
         if (!postImgList.isEmpty()) {
             storageCleanupService.deletePostImagesAfterCommit(postImgList, DIR_NAME);

--- a/src/test/java/com/mogak/spring/repository/PostCommentRepositoryTest.java
+++ b/src/test/java/com/mogak/spring/repository/PostCommentRepositoryTest.java
@@ -6,7 +6,7 @@ import com.mogak.spring.domain.modarat.Modarat;
 import com.mogak.spring.domain.mogak.Mogak;
 import com.mogak.spring.domain.mogak.MogakCategory;
 import com.mogak.spring.domain.post.Post;
-import com.mogak.spring.domain.post.PostLike;
+import com.mogak.spring.domain.post.PostComment;
 import com.mogak.spring.domain.user.Address;
 import com.mogak.spring.domain.user.Job;
 import com.mogak.spring.domain.user.User;
@@ -21,69 +21,41 @@ import org.springframework.test.context.ActiveProfiles;
 import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ActiveProfiles("test")
 @DataJpaTest
-class PostLikeRepositoryTest {
+class PostCommentRepositoryTest {
 
     @Autowired
     private TestEntityManager entityManager;
     @Autowired
-    private PostLikeRepository postLikeRepository;
+    private PostCommentRepository postCommentRepository;
 
     @Test
-    @DisplayName("같은 사용자는 같은 게시글에 좋아요를 중복 생성할 수 없다")
-    void postLikeHasUniquePostUserConstraint() {
+    @DisplayName("한 사용자는 같은 게시글에 댓글을 여러 개 작성할 수 있다")
+    void sameUserCanWriteMultipleCommentsOnPost() {
         User user = persistUser();
         Post post = persistPost(user);
-        entityManager.persist(PostLike.builder()
+        entityManager.persist(PostComment.builder()
                 .post(post)
                 .user(user)
+                .contents("첫 번째 댓글")
                 .build());
-        entityManager.flush();
-
-        assertThatThrownBy(() -> {
-            entityManager.persist(PostLike.builder()
-                    .post(post)
-                    .user(user)
-                    .build());
-            entityManager.flush();
-        })
-                .isInstanceOf(org.hibernate.exception.ConstraintViolationException.class);
-    }
-
-    @Test
-    @DisplayName("게시글 기준 좋아요 삭제는 해당 게시글의 좋아요를 hard delete 한다")
-    void deleteAllByPostHardDeletesLikesForPost() {
-        User owner = persistUser("owner@test.com", "owner");
-        User liker = persistUser("liker@test.com", "liker");
-        Post post = persistPost(owner);
-        entityManager.persist(PostLike.builder()
+        entityManager.persist(PostComment.builder()
                 .post(post)
-                .user(owner)
+                .user(user)
+                .contents("두 번째 댓글")
                 .build());
-        entityManager.persist(PostLike.builder()
-                .post(post)
-                .user(liker)
-                .build());
-        entityManager.flush();
-
-        postLikeRepository.deleteAllByPost(post);
         entityManager.flush();
         entityManager.clear();
 
-        assertThat(postLikeRepository.count()).isZero();
+        assertThat(postCommentRepository.count()).isEqualTo(2);
     }
 
     private User persistUser() {
-        return persistUser("like@test.com", "like");
-    }
-
-    private User persistUser(String email, String nickname) {
         Job job = entityManager.persist(TestFixtureFactory.job("개발/데이터"));
         Address address = entityManager.persist(TestFixtureFactory.address("서울특별시"));
-        return entityManager.persist(TestFixtureFactory.user(null, email, nickname, job, address));
+        return entityManager.persist(TestFixtureFactory.user(null, "comment@test.com", "commenter", job, address));
     }
 
     private Post persistPost(User user) {

--- a/src/test/java/com/mogak/spring/service/AuthServiceTest.java
+++ b/src/test/java/com/mogak/spring/service/AuthServiceTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -196,5 +197,7 @@ class AuthServiceTest {
         assertThat(comment.isDeleted()).isTrue();
         assertThat(post.getCommentCnt()).isZero();
         assertThat(post.getLikeCnt()).isZero();
+        verify(postLikeRepository).deleteAllRelatedToUser(1L);
+        verify(followRepository).deleteAllRelatedToUser(1L);
     }
 }

--- a/src/test/java/com/mogak/spring/service/JogakServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/JogakServiceImplTest.java
@@ -46,6 +46,7 @@ class JogakServiceImplTest {
     @Mock private PeriodRepository periodRepository;
     @Mock private DailyJogakRepository dailyJogakRepository;
     @Mock private PostRepository postRepository;
+    @Mock private PostLikeRepository postLikeRepository;
     @Mock private PostCommentRepository postCommentRepository;
     @Mock private PostImgRepository postImgRepository;
     @Mock private StorageCleanupService storageCleanupService;
@@ -442,6 +443,32 @@ class JogakServiceImplTest {
     }
 
     @Test
+    @DisplayName("조각 수정은 이미 생성된 데일리 조각의 제목과 루틴 여부 스냅샷을 바꾸지 않는다")
+    void updateJogakKeepsExistingDailyJogakSnapshot() {
+        User owner = TestFixtureFactory.user(1L, "owner@test.com", "owner", null, null);
+        Mogak mogak = TestFixtureFactory.mogak(2L,
+                owner,
+                TestFixtureFactory.modarat(1L, owner, "모다라트", "#0000"),
+                TestFixtureFactory.category(1, "자격증"),
+                "모각",
+                "#1234");
+        Jogak jogak = TestFixtureFactory.jogak(10L, mogak, "기존 조각", true, LocalDate.now(), null, 0);
+        DailyJogak dailyJogak = TestFixtureFactory.dailyJogak(100L, jogak, LocalDate.now(), DailyJogakStatus.PENDING);
+        JogakRequestDto.UpdateJogakDto request = new JogakRequestDto.UpdateJogakDto();
+        ReflectionTestUtils.setField(request, "title", "수정 조각");
+        ReflectionTestUtils.setField(request, "isRoutine", false);
+        lenient().when(dailyJogakRepository.findActiveAllByJogak(jogak)).thenReturn(List.of(dailyJogak));
+        when(jogakRepository.findActiveById(10L)).thenReturn(Optional.of(jogak));
+
+        JogakResponseDto.CreateJogakDto result = jogakService.updateJogak(owner.getId(), 10L, request);
+
+        assertThat(result.getTitle()).isEqualTo("수정 조각");
+        assertThat(result.getIsRoutine()).isFalse();
+        assertThat(dailyJogak.getTitle()).isEqualTo("기존 조각");
+        assertThat(dailyJogak.getIsRoutine()).isTrue();
+    }
+
+    @Test
     @DisplayName("타인 조각 삭제 요청을 하면 권한 오류를 반환한다")
     void deleteJogakThrowsWhenOwnerMismatch() {
         User owner = TestFixtureFactory.user(1L, "owner@test.com", "owner", null, null);
@@ -511,6 +538,7 @@ class JogakServiceImplTest {
         assertThat(jogak.isDeleted()).isTrue();
         assertThat(post.getCommentCnt()).isZero();
         verify(storageCleanupService).deletePostImagesAfterCommit(List.of(postImg), "img");
+        verify(postLikeRepository).deleteAllByPost(post);
         verify(postImgRepository).deleteAllByPost(post);
         verify(jogakPeriodRepository).deleteAllByJogakId(10L);
     }

--- a/src/test/java/com/mogak/spring/service/JogakServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/JogakServiceImplTest.java
@@ -457,7 +457,6 @@ class JogakServiceImplTest {
         JogakRequestDto.UpdateJogakDto request = new JogakRequestDto.UpdateJogakDto();
         ReflectionTestUtils.setField(request, "title", "수정 조각");
         ReflectionTestUtils.setField(request, "isRoutine", false);
-        lenient().when(dailyJogakRepository.findActiveAllByJogak(jogak)).thenReturn(List.of(dailyJogak));
         when(jogakRepository.findActiveById(10L)).thenReturn(Optional.of(jogak));
 
         JogakResponseDto.CreateJogakDto result = jogakService.updateJogak(owner.getId(), 10L, request);

--- a/src/test/java/com/mogak/spring/service/PostServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/PostServiceImplTest.java
@@ -48,6 +48,8 @@ class PostServiceImplTest {
     @Mock
     private PostImgRepository postImgRepository;
     @Mock
+    private PostLikeRepository postLikeRepository;
+    @Mock
     private PostCommentRepository postCommentRepository;
     @Mock
     private StorageCleanupService storageCleanupService;
@@ -313,8 +315,43 @@ class PostServiceImplTest {
         postService.delete(1L, 10L);
 
         assertThat(post.isDeleted()).isTrue();
+        verify(postLikeRepository).deleteAllByPost(post);
         verify(storageCleanupService, never()).deletePostImagesAfterCommit(anyList(), any());
         verify(postImgRepository, never()).deleteAllByPost(post);
+    }
+
+    @Test
+    @DisplayName("게시글 삭제는 좋아요와 이미지를 hard delete 하고 댓글과 게시글은 soft delete 한다")
+    void deleteHardDeletesLikesAndImagesThenSoftDeletesCommentsAndPost() {
+        User owner = user(1L, "owner@test.com");
+        User commenter = user(2L, "commenter@test.com");
+        Post post = post(10L, owner);
+        ReflectionTestUtils.setField(post, "commentCnt", 1);
+        PostImg postImg = PostImg.builder()
+                .id(30L)
+                .post(post)
+                .imgName("img.png")
+                .imgUrl("https://example.com/img.png")
+                .build();
+        PostComment comment = PostComment.builder()
+                .id(20L)
+                .post(post)
+                .user(commenter)
+                .contents("comment")
+                .build();
+
+        when(postRepository.findActiveById(10L)).thenReturn(Optional.of(post));
+        when(postImgRepository.findAllByPost(post)).thenReturn(List.of(postImg));
+        when(postCommentRepository.findActiveAllByPostForCleanup(post)).thenReturn(List.of(comment));
+
+        postService.delete(1L, 10L);
+
+        assertThat(comment.isDeleted()).isTrue();
+        assertThat(post.isDeleted()).isTrue();
+        assertThat(post.getCommentCnt()).isZero();
+        verify(postLikeRepository).deleteAllByPost(post);
+        verify(storageCleanupService).deletePostImagesAfterCommit(List.of(postImg), "img");
+        verify(postImgRepository).deleteAllByPost(post);
     }
 
     @Test
@@ -341,6 +378,7 @@ class PostServiceImplTest {
         assertThat(comment.isDeleted()).isTrue();
         assertThat(post.getCommentCnt()).isZero();
         assertThat(post.isDeleted()).isTrue();
+        verify(postLikeRepository).deleteAllByPost(post);
         verify(postCommentRepository).findActiveAllByPostForCleanup(post);
         verify(postCommentRepository, never()).findActiveAllByPost(post);
     }


### PR DESCRIPTION
## Summary
  - ERD/삭제 생명주기 공개 문서를 추가했습니다.
  - `PostComment.user`를 `OneToOne`에서 `ManyToOne`으로 수정해 한 사용자의 복수 댓글 작성을 허용했습니다.
  - 게시글/조각 삭제 시 `PostLike`를 hard delete하도록 정리했습니다.
  - 조각 수정 시 기존 `DailyJogak.title/isRoutine` 스냅샷을 갱신하지 않도록 변경했습니다.

  ## Changes
  - `docs/operations/policies/ERD_DECISIONS_AND_LIFECYCLE.md` 추가
    - soft delete / hard delete / preserve / policy pending 생명주기 정리
    - `DailyJogak` 생성 규칙과 snapshot 의미 문서화
    - `AgreeUser`는 실제 약관 동의 모델로 유지하되 보존/익명화/삭제 정책은 pending으로 명시
  - `PostComment.user`
    - `@OneToOne(fetch = LAZY)` → `@ManyToOne(fetch = LAZY)`
  - 삭제 정리
    - `PostLikeRepository.deleteAllByPost(post)` 추가
    - `PostServiceImpl.delete()`에서 게시글 soft delete 전 `PostLike` hard delete
    - `JogakServiceImpl.deletePostCascade()`에서 하위 게시글의 `PostLike` hard delete
    - 댓글 soft delete, 이미지 hard delete/storage cleanup, 게시글 soft delete 정책은 유지
  - `JogakServiceImpl.updateJogak()`
    - 기존 active `DailyJogak`에 `dailyJogak.updateJogak(jogak)`를 호출하던 로직 제거
  
  ## Notes
  - 이번 PR에서는 `DailyJogak` FK 제거, `BlockUser` rename, unique schema 정리, 회원탈퇴 유스케이스 분리는 하지 않습니다.
  - 운영 DB에 과거 `post_comment.user_id` unique 제약이 남아 있지 않은지 배포 전 확인이 필요합니다.

## 관련 이슈
#140 