### PR TITLE
perf: 주요 목록 API N+1 조회 전략 개선

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@
 - [프로젝트 규약](operations/policies/PROJECT_CONVENTIONS.md)
 - [스택 마이그레이션 가이드](operations/policies/STACK_MIGRATION_GUIDE.md)
 - [ERD 및 삭제 라이프사이클](operations/policies/ERD_DECISIONS_AND_LIFECYCLE.md)
+- [조회 전략 및 N+1 가드레일](operations/policies/QUERY_STRATEGY_AND_N_PLUS_ONE.md)
 - [외부 리뷰 워크플로우](operations/policies/EXTERNAL_REVIEW_WORKFLOW.md)
 - [도메인 문서 레지스트리](operations/policies/DOMAIN_DOCUMENT_REGISTRY.md)
 - [가이던스 스키마](operations/policies/guidance-schema.md)

--- a/docs/operations/policies/DOMAIN_DOCUMENT_REGISTRY.md
+++ b/docs/operations/policies/DOMAIN_DOCUMENT_REGISTRY.md
@@ -20,7 +20,7 @@
 | follow-networking | `PROJECT_CONVENTIONS.md`, `.codex/rules/spring-core.md`, `.codex/rules/testing.md` | yes |
 | scheduler | `PROJECT_CONVENTIONS.md`, `.codex/rules/testing.md`, `.codex/workflows/full-delivery.md` | yes |
 | storage | `PROJECT_CONVENTIONS.md`, `.codex/rules/persistence.md`, `.codex/workflows/full-delivery.md` | yes |
-| persistence | `PROJECT_CONVENTIONS.md`, `.codex/rules/persistence.md`, `EXTERNAL_REVIEW_WORKFLOW.md` | no |
+| persistence | `PROJECT_CONVENTIONS.md`, `QUERY_STRATEGY_AND_N_PLUS_ONE.md`, `.codex/rules/persistence.md`, `EXTERNAL_REVIEW_WORKFLOW.md` | no |
 | data-lifecycle | `PROJECT_CONVENTIONS.md`, `ERD_DECISIONS_AND_LIFECYCLE.md`, `EXTERNAL_REVIEW_WORKFLOW.md` | yes |
 | platform-common | `PROJECT_CONVENTIONS.md`, `STACK_MIGRATION_GUIDE.md`, `.codex/rules/spring-core.md`, `.codex/workflows/refactor-guarded.md` | no |
 

--- a/docs/operations/policies/QUERY_STRATEGY_AND_N_PLUS_ONE.md
+++ b/docs/operations/policies/QUERY_STRATEGY_AND_N_PLUS_ONE.md
@@ -1,0 +1,71 @@
+# Query Strategy and N+1 Guardrails
+
+이 문서는 `MOGAK_Spring`의 공개 가능한 ORM-first 조회 전략과 N+1 검증 기준을 정리한다.
+
+## Scope
+- Spring Data JPA와 JPQL을 기본 조회 수단으로 본다.
+- SQL 튜닝, 인덱스, 캐시, 비공개 서비스 정책 판단은 이 문서의 범위가 아니다.
+- API별 응답 필드와 접근 권한처럼 공개 규칙만으로 판단할 수 없는 내용은 비공개 정책 consult 또는 사용자 확인이 필요하다.
+
+## Default Strategy
+- 새 조회 코드는 ORM-first로 설계한다.
+- Repository는 조회 형태와 저장만 담당하고, 비즈니스 정책 판단을 넣지 않는다.
+- 응답 조립에서 접근하는 연관관계는 쿼리 전략에 명시적으로 반영한다.
+- 목록, 상세, 배치 조회를 구현할 때는 DTO 조립 과정의 연관 접근까지 포함해 N+1 위험을 점검한다.
+- 최적화는 실제 응답에 필요한 데이터 기준으로 수행하고, 불필요한 범용 fetch 전략을 만들지 않는다.
+
+## To-One Associations
+- 목록 또는 상세 응답에서 필요한 `ManyToOne`, `OneToOne` 연관은 JPQL `join fetch`를 우선 검토한다.
+- to-one fetch join은 row 증폭 위험이 낮으므로, 응답 조립에서 항상 필요한 소유자, 작성자, 부모 참조 조회에 적합하다.
+- 조건부로만 필요한 to-one 데이터는 별도 projection 또는 전용 조회 메서드를 검토한다.
+- EntityGraph는 기존 Repository 패턴과 더 잘 맞고 조회 의도가 분명할 때 사용한다.
+
+## Collections and Paging
+- 페이징 쿼리에서는 컬렉션 fetch join을 사용하지 않는다.
+- 컬렉션 fetch join은 row 중복, 잘못된 page size, 메모리 페이징 위험을 만들 수 있다.
+- 페이징된 루트 엔티티 목록을 먼저 조회한 뒤, 필요한 컬렉션 데이터는 루트 id 목록으로 배치 JPQL 조회한다.
+- 배치 JPQL은 `where root.id in :ids` 형태로 필요한 컬렉션 또는 projection만 조회한다.
+- 조회 결과는 애플리케이션 계층에서 루트 id 기준으로 그룹핑해 DTO에 조립한다.
+- page size가 커지거나 여러 컬렉션이 동시에 필요하면 API 응답 형태, projection, 별도 summary 필드로 요구사항을 다시 분리한다.
+
+## Recommended Patterns
+- 상세 조회:
+  - 필요한 to-one 연관은 JPQL fetch join 또는 EntityGraph로 함께 조회한다.
+  - 필요한 컬렉션이 작고 페이징이 없을 때만 컬렉션 fetch join을 제한적으로 검토한다.
+- 페이징 목록 조회:
+  - 루트 엔티티 page 조회와 to-one fetch join을 결합한다.
+  - 컬렉션 데이터는 page의 루트 id 목록으로 별도 배치 조회한다.
+  - DTO 조립은 이미 조회한 데이터만 사용하고 lazy loading에 의존하지 않는다.
+- 댓글, 이미지, 좋아요 수처럼 컬렉션 전체가 아니라 요약값만 필요한 경우:
+  - collection entity 로딩보다 count, exists, projection 조회를 우선 검토한다.
+- 배치/스케줄러 조회:
+  - 처리 단위별 id를 먼저 제한하고, 필요한 연관을 명시적으로 조회한다.
+  - 반복문 내부에서 lazy association을 열어 추가 쿼리가 누적되지 않게 한다.
+
+## Query Count Validation
+- 검증 목표는 사전에 고정한 절대 쿼리 수를 맞추는 것이 아니라 데이터 크기 증가에 따른 비선형 증가를 막는 것이다.
+- 대표 page size와 더 큰 page size를 비교해 쿼리 수가 page item 수에 비례해 증가하지 않는지 확인한다.
+- 같은 응답 형태에서 루트 row 수를 늘렸을 때 쿼리 수가 선형 또는 상수 범위로 유지되는지 본다.
+- 반복문 내부 lazy loading으로 `1 + N`, `1 + 2N`, `1 + N * M` 형태가 나타나면 N+1 위험으로 본다.
+- 테스트 또는 로깅 기반 검증은 API 특성, 사용 데이터, 현재 ORM 설정을 함께 기록한다.
+- hard target이 필요한 성능 기준은 이 공개 문서가 아니라 별도 운영 기준에서 다룬다.
+
+## Current Coverage
+현재 공개 회귀 테스트는 `ListQueryCountIntegrationTest`에서 Hibernate statistics의 `prepareStatementCount`를 사용한다. 절대 쿼리 수를 고정하지 않고, 동일 응답 형태에서 1개 루트 row와 3개 루트 row를 조회했을 때 쿼리 수가 증가하지 않는지 확인한다.
+
+| 목록 | 검증 대상 | 조회 전략 | 회귀 테스트 |
+| --- | --- | --- | --- |
+| 네트워크 게시글 목록 | 게시글, 작성자, 직무, 이미지 | 게시글 page 조회에 to-one fetch join, 이미지는 post id 배치 조회 | `networkPostsQueryCountDoesNotGrowWithPostCount` |
+| 페이스메이커 게시글 목록 | 게시글, 작성자, 직무, 이미지, 댓글 작성자 | 게시글 page 조회에 to-one fetch join, 이미지/댓글은 post id 배치 조회 | `pacemakerPostsQueryCountDoesNotGrowWithPostCount` |
+| 모각별 게시글 목록 | 게시글, daily jogak, jogak, mogak | 게시글 page 조회에 필요한 to-one fetch join | `mogakPostsQueryCountDoesNotGrowWithPostCount` |
+| 모각 목록 | 모각, 대분류 | 모각 목록 조회에 대분류 fetch join | `mogakListQueryCountDoesNotGrowWithMogakCount` |
+| 조각 목록 | 조각, 모각, 대분류, 요일 | 조각 목록 조회에 응답 변환용 fetch graph | `jogakListQueryCountDoesNotGrowWithJogakCount` |
+| 댓글 목록 | 댓글, 게시글, 작성자 | 댓글 조회에 게시글/작성자 fetch join | `commentListQueryCountDoesNotGrowWithCommentCount` |
+
+## Review Checklist
+- 응답 DTO 조립 중 접근하는 모든 연관관계를 확인했는가?
+- 페이징 쿼리에 컬렉션 fetch join이 들어가지 않았는가?
+- page 루트 id 기준 배치 조회로 컬렉션 데이터를 가져오는가?
+- to-one 연관은 JPQL fetch join 또는 EntityGraph로 명시했는가?
+- query-count 검증이 고정 숫자 대신 데이터 증가에 따른 증가 패턴을 확인하는가?
+- 공개 문서만으로 결정할 수 없는 정책 판단을 조회 계층에 숨기지 않았는가?

--- a/src/main/java/com/mogak/spring/repository/DailyJogakRepository.java
+++ b/src/main/java/com/mogak/spring/repository/DailyJogakRepository.java
@@ -28,7 +28,7 @@ public interface DailyJogakRepository extends JpaRepository<DailyJogak, Long> {
     }
 
     @Query("SELECT j from DailyJogak j " +
-            "JOIN FETCH j.mogak jm JOIN FETCH jm.user u " +
+            "JOIN FETCH j.mogak jm JOIN FETCH jm.user u JOIN FETCH j.jogak jogak " +
             "WHERE jm.user = :user and j.targetDate = :targetDate " +
             "AND j.deletedAt is null AND jm.deletedAt is null AND u.deletedAt is null")
     List<DailyJogak> findDailyJogaks(@Param(value = "user") User user,

--- a/src/main/java/com/mogak/spring/repository/JogakRepository.java
+++ b/src/main/java/com/mogak/spring/repository/JogakRepository.java
@@ -30,6 +30,14 @@ public interface JogakRepository extends JpaRepository<Jogak, Long> {
     @Query("select j from Jogak j where j.mogak = :mogak and j.deletedAt is null and j.mogak.deletedAt is null")
     List<Jogak> findAllByMogak(@Param("mogak") Mogak mogak);
 
+    @Query("select distinct j from Jogak j " +
+            "join fetch j.mogak m " +
+            "join fetch j.category c " +
+            "left join fetch j.jogakPeriods jp " +
+            "left join fetch jp.period " +
+            "where j.mogak = :mogak and j.deletedAt is null and m.deletedAt is null")
+    List<Jogak> findAllByMogakWithFetchGraph(@Param("mogak") Mogak mogak);
+
     @Query("select count(j) from Jogak j " +
             "where j.mogak = :mogak and j.deletedAt is null and j.mogak.deletedAt is null " +
             "and (j.endAt is null or j.endAt > :today)")

--- a/src/main/java/com/mogak/spring/repository/MogakRepository.java
+++ b/src/main/java/com/mogak/spring/repository/MogakRepository.java
@@ -11,7 +11,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MogakRepository extends JpaRepository<Mogak, Long> {
-    @Query("select m from Mogak m where m.modarat.id = :modaratId and m.deletedAt is null and m.modarat.deletedAt is null")
+    @Query("select m from Mogak m join fetch m.bigCategory c " +
+            "where m.modarat.id = :modaratId and m.deletedAt is null and m.modarat.deletedAt is null")
     List<Mogak> findAllByModaratId(@Param("modaratId") Long modaratId);
 
     @Query("select m from Mogak m where m.id = :mogakId and m.deletedAt is null and m.user.deletedAt is null")

--- a/src/main/java/com/mogak/spring/repository/PostCommentRepository.java
+++ b/src/main/java/com/mogak/spring/repository/PostCommentRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,8 +22,14 @@ public interface PostCommentRepository extends JpaRepository<PostComment, Long> 
     }
 
     //댓글 여러개 조회
-    @Query("select pc from PostComment pc join pc.user u where pc.post = :post and pc.deletedAt is null and u.deletedAt is null")
+    @Query("select pc from PostComment pc join fetch pc.user u where pc.post = :post and pc.deletedAt is null and u.deletedAt is null")
     List<PostComment> findActiveAllByPost(@Param("post") Post post);
+
+    @Query("select pc from PostComment pc " +
+            "join fetch pc.post p " +
+            "join fetch pc.user u " +
+            "where p.id in :postIds and pc.deletedAt is null and p.deletedAt is null and u.deletedAt is null")
+    List<PostComment> findActiveAllByPostIdInWithUser(@Param("postIds") Collection<Long> postIds);
 
     @Query("select pc from PostComment pc where pc.post = :post and pc.deletedAt is null")
     List<PostComment> findActiveAllByPostForCleanup(@Param("post") Post post);

--- a/src/main/java/com/mogak/spring/repository/PostImgRepository.java
+++ b/src/main/java/com/mogak/spring/repository/PostImgRepository.java
@@ -7,11 +7,13 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface PostImgRepository extends JpaRepository<PostImg, Long> {
 
     List<PostImg> findAllByPost(Post post);
+    List<PostImg> findAllByPostIdIn(Collection<Long> postIds);
     void deleteAllByPost(Post post);
 
     @Query("select pi from PostImg pi where pi.post.user.id = :userId")

--- a/src/main/java/com/mogak/spring/repository/PostRepository.java
+++ b/src/main/java/com/mogak/spring/repository/PostRepository.java
@@ -19,7 +19,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     //slice 사용해 별도의 카운트 쿼리를 호출하지 않고 원래 갯수보다 1개 더 불러와 다음에 조회할 회고록 있는지 확인할 수 있음
     //fetch join시 where 절에 join의 대상에 대한 조건 써도 될까?
     @Query("select p from Post p " +
-            "join p.dailyJogak dj join dj.jogak j join j.mogak m join p.user u " +
+            "join fetch p.dailyJogak dj join fetch dj.jogak j join fetch j.mogak m join p.user u " +
             "where m.id = :mogakId and p.deletedAt is null and dj.deletedAt is null " +
             "and j.deletedAt is null and m.deletedAt is null and u.deletedAt is null " +
             "order by p.id desc")
@@ -59,7 +59,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findActiveAllByUserId(@Param("userId") Long userId);
 
     @Query( "SELECT p " +
-            "FROM Post p JOIN Follow f ON p.user = f.toUser JOIN p.user u " +
+            "FROM Post p JOIN Follow f ON p.user = f.toUser JOIN FETCH p.user u JOIN FETCH u.job " +
             "JOIN p.dailyJogak dj JOIN dj.jogak j JOIN j.mogak m " +
             "WHERE f.fromUser = :user and p.deletedAt is null and u.deletedAt is null " +
             "and f.fromUser.deletedAt is null and dj.deletedAt is null " +
@@ -74,7 +74,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             + "CASE WHEN :sort = 'likeCnt' THEN p.likeCnt END DESC")
 
      */
-    @Query("SELECT p FROM Post p JOIN FETCH p.user u " +
+    @Query("SELECT p FROM Post p JOIN FETCH p.user u JOIN FETCH u.job " +
             "JOIN p.dailyJogak dj JOIN dj.jogak j JOIN j.mogak m " +
             "WHERE u.address.name = :address AND p.deletedAt is null AND u.deletedAt is null " +
             "AND dj.deletedAt is null AND j.deletedAt is null AND m.deletedAt is null ORDER BY "

--- a/src/main/java/com/mogak/spring/service/MogakServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/MogakServiceImpl.java
@@ -239,7 +239,7 @@ public class MogakServiceImpl implements MogakService {
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         Mogak mogak = getOwnedMogak(mogakId, userId);
         List<DailyJogak> dailyJogak = dailyJogakRepository.findDailyJogaks(user, day);
-        return jogakRepository.findAllByMogak(mogak).stream()
+        return jogakRepository.findAllByMogakWithFetchGraph(mogak).stream()
                 .filter(jogak -> jogak.getEndAt() == null || jogak.getEndAt().isAfter(day.minusDays(1)))
                 .map(jogak -> JogakConverter.toGetJogakResponseDto(jogak, findCorrespondingDailyJogak(jogak, dailyJogak)))
                 .collect(Collectors.toList());

--- a/src/main/java/com/mogak/spring/service/PostService.java
+++ b/src/main/java/com/mogak/spring/service/PostService.java
@@ -4,6 +4,8 @@ import com.mogak.spring.domain.post.Post;
 import com.mogak.spring.domain.post.PostImg;
 import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
 import com.mogak.spring.web.dto.postdto.PostRequestDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.GetAllNetworkDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.GetPostDto;
 import org.springframework.data.domain.Slice;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,12 +19,12 @@ public interface PostService {
     void validateCreateAccess(Long userId, PostRequestDto.CreatePostDto request, List<MultipartFile> multipartFile, Long jogakId);
     Post create(Long userId, PostRequestDto.CreatePostDto request, List<PostImgRequestDto.CreatePostImgDto> postImgDtoList, Long jogakId);
     Post getByJogakAndTargetDate(Long userId, Long jogakId, LocalDate targetDate);
-    Slice<Post> getAllPosts(Long userId, int page, Long mogakId, int size);
+    Slice<GetPostDto> getAllPosts(Long userId, int page, Long mogakId, int size);
     Post findById(Long userId, Long postId);
     Post update(Long userId, Long postId, PostRequestDto.UpdatePostDto request);
     void delete(Long userId, Long postId);
     List<NetworkPostDto> getPacemakerPosts(Long userId, int cursor, int size);
-    Slice<Post> getNetworkPosts(Long userId, int page, int size, String sort, String address);
+    Slice<GetAllNetworkDto> getNetworkPosts(Long userId, int page, int size, String sort, String address);
     List<String> findImgUrlByPost(Long postId);
     List<Long> findActiveCommentIds(Post post);
     List<String> findNotThumbnailImg(Post post);

--- a/src/main/java/com/mogak/spring/service/PostServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/PostServiceImpl.java
@@ -20,6 +20,8 @@ import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.repository.*;
 import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
 import com.mogak.spring.web.dto.postdto.PostRequestDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.GetAllNetworkDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.GetPostDto;
 import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkPostDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -32,8 +34,10 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -114,11 +118,12 @@ public class PostServiceImpl implements PostService {
 
     //회고록 조회 - 무한 스크롤
     @Override
-    public Slice<Post> getAllPosts(Long userId, int page, Long mogakId, int size) {
+    public Slice<GetPostDto> getAllPosts(Long userId, int page, Long mogakId, int size) {
         getOwnedMogak(userId, mogakId);
         Pageable pageable = PageRequest.of(page, size);
 
-        return postRepository.findAllPosts(mogakId, pageable);
+        return postRepository.findAllPosts(mogakId, pageable)
+                .map(PostConverter::toGetPostDto);
     }
 
     //회고록 상세 조회 + 댓글, 이미지 같이 보이게
@@ -169,31 +174,30 @@ public class PostServiceImpl implements PostService {
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         Pageable pageable = PageRequest.of(cursor, size);
         List<Post> posts = postRepository.findPacemakerPostsByUser(user, pageable);
-        //postImg 중 썸네일 이미지는 제외
+        List<Long> postIds = extractPostIds(posts);
+        Map<Long, List<PostImg>> imagesByPostId = groupImagesByPostId(postIds);
+        Map<Long, List<PostComment>> commentsByPostId = groupCommentsByPostId(postIds);
+
         return posts.stream()
                 .map(p -> {
-                    List<String> imgUrls = postImgRepository.findAllByPost(p).stream()
-                            .filter(img -> !Objects.equals(img.getImgUrl(), p.getPostThumbnailUrl()))
-                            .map(PostImg::getImgUrl)
-                            .collect(Collectors.toList());
-                    NetworkPostDto dto = NetworkPostDto.builder()
+                    List<String> imgUrls = findNotThumbnailImgUrls(p, imagesByPostId);
+                    return NetworkPostDto.builder()
                             .user(UserConverter.toUserDto(p.getUser()))
                             .contents(p.getContents())
                             .imgUrls(imgUrls)
-                            .comments(postCommentRepository.findActiveAllByPost(p).stream()
+                            .comments(commentsByPostId.getOrDefault(p.getId(), Collections.emptyList()).stream()
                                     .map(CommentConverter::toNetworkCommentDto)
                                     .collect(Collectors.toList()))
                             .likeCnt(p.getLikeCnt())
                             .viewCnt(p.getViewCnt())
                             .build();
-                    return dto;
                 })
                 .collect(Collectors.toList());
     }
 
     //전체 네트워킹 조회 - 이미지 썸네일 제외 반환
     @Override
-    public Slice<Post> getNetworkPosts(Long userId, int page, int size, String sort, String address /*List<String> categoryList,*/){
+    public Slice<GetAllNetworkDto> getNetworkPosts(Long userId, int page, int size, String sort, String address /*List<String> categoryList,*/){
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         if(address == null){
@@ -201,7 +205,45 @@ public class PostServiceImpl implements PostService {
         }
         Pageable pageable = PageRequest.of(page, size);
         Slice<Post> posts = postRepository.findNetworkPosts(address, sort, pageable);
-        return posts;
+        Map<Long, List<PostImg>> imagesByPostId = groupImagesByPostId(extractPostIds(posts.getContent()));
+        return posts.map(post -> GetAllNetworkDto.builder()
+                .postId(post.getId())
+                .userName(post.getUser().getNickname())
+                .userJob(post.getUser().getJob().getName())
+                .contents(post.getContents())
+                .imgUrls(findNotThumbnailImgUrls(post, imagesByPostId))
+                .commentCnt(post.getCommentCnt())
+                .likeCnt(post.getLikeCnt())
+                .build());
+    }
+
+    private List<Long> extractPostIds(List<Post> posts) {
+        return posts.stream()
+                .map(Post::getId)
+                .collect(Collectors.toList());
+    }
+
+    private Map<Long, List<PostImg>> groupImagesByPostId(List<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return postImgRepository.findAllByPostIdIn(postIds).stream()
+                .collect(Collectors.groupingBy(postImg -> postImg.getPost().getId()));
+    }
+
+    private Map<Long, List<PostComment>> groupCommentsByPostId(List<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return postCommentRepository.findActiveAllByPostIdInWithUser(postIds).stream()
+                .collect(Collectors.groupingBy(comment -> comment.getPost().getId()));
+    }
+
+    private List<String> findNotThumbnailImgUrls(Post post, Map<Long, List<PostImg>> imagesByPostId) {
+        return imagesByPostId.getOrDefault(post.getId(), Collections.emptyList()).stream()
+                .filter(img -> !Objects.equals(img.getImgUrl(), post.getPostThumbnailUrl()))
+                .map(PostImg::getImgUrl)
+                .collect(Collectors.toList());
     }
 
     /*

--- a/src/main/java/com/mogak/spring/web/controller/NetworkController.java
+++ b/src/main/java/com/mogak/spring/web/controller/NetworkController.java
@@ -1,8 +1,6 @@
 package com.mogak.spring.web.controller;
 
 
-import com.mogak.spring.converter.PostConverter;
-import com.mogak.spring.domain.post.Post;
 import com.mogak.spring.exception.ErrorResponse;
 import com.mogak.spring.global.BaseResponse;
 import com.mogak.spring.jwt.AuthenticatedUser;
@@ -97,8 +95,8 @@ public class NetworkController {
             @RequestParam(value = "page", defaultValue = "0") int page, @RequestParam(value = "size") int size,
             @RequestParam(value = "sort", defaultValue = "createdAt", required = false) String sort, @RequestParam(value = "address", required = false) String address
             /*@RequestParam(value = "category", defaultValue="all", required = false) List<String> categoryList,*/) {
-        Slice<Post> posts = postService.getNetworkPosts(authenticatedUser.getUserId(), page, size, sort, address);
-        return ResponseEntity.ok(new BaseResponse<>(PostConverter.toNetworkPagingDto(posts)));
+        Slice<PostResponseDto.GetAllNetworkDto> posts = postService.getNetworkPosts(authenticatedUser.getUserId(), page, size, sort, address);
+        return ResponseEntity.ok(new BaseResponse<>(posts));
     }
 
 

--- a/src/main/java/com/mogak/spring/web/controller/PostController.java
+++ b/src/main/java/com/mogak/spring/web/controller/PostController.java
@@ -89,9 +89,8 @@ public class PostController {
                                                                        @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                        @RequestParam(value = "page", defaultValue = "0") int page,
                                                                        @RequestParam(value = "size") int size) {
-        Slice<Post> posts = postService.getAllPosts(authenticatedUser.getUserId(), page, mogakId, size);
-        //다음페이지 존재 여부 전달 필요
-        return ResponseEntity.ok(new BaseResponse<>(PostConverter.toPostPagingDto(posts)));
+        Slice<GetPostDto> posts = postService.getAllPosts(authenticatedUser.getUserId(), page, mogakId, size);
+        return ResponseEntity.ok(new BaseResponse<>(posts));
     }
 
     @GetMapping("/api/jogaks/{jogakId}/posts")

--- a/src/test/java/com/mogak/spring/integration/ListQueryCountIntegrationTest.java
+++ b/src/test/java/com/mogak/spring/integration/ListQueryCountIntegrationTest.java
@@ -1,0 +1,378 @@
+package com.mogak.spring.integration;
+
+import com.mogak.spring.auth.AppleOAuthUserProvider;
+import com.mogak.spring.domain.jogak.DailyJogak;
+import com.mogak.spring.domain.jogak.DailyJogakStatus;
+import com.mogak.spring.domain.jogak.Jogak;
+import com.mogak.spring.domain.jogak.Period;
+import com.mogak.spring.domain.modarat.Modarat;
+import com.mogak.spring.domain.mogak.Mogak;
+import com.mogak.spring.domain.mogak.MogakCategory;
+import com.mogak.spring.domain.post.Post;
+import com.mogak.spring.domain.post.PostComment;
+import com.mogak.spring.domain.post.PostImg;
+import com.mogak.spring.domain.user.Address;
+import com.mogak.spring.domain.user.Follow;
+import com.mogak.spring.domain.user.Job;
+import com.mogak.spring.domain.user.User;
+import com.mogak.spring.repository.AddressRepository;
+import com.mogak.spring.repository.DailyJogakRepository;
+import com.mogak.spring.repository.FollowRepository;
+import com.mogak.spring.repository.JobRepository;
+import com.mogak.spring.repository.JogakPeriodRepository;
+import com.mogak.spring.repository.JogakRepository;
+import com.mogak.spring.repository.ModaratRepository;
+import com.mogak.spring.repository.MogakCategoryRepository;
+import com.mogak.spring.repository.MogakRepository;
+import com.mogak.spring.repository.PostCommentRepository;
+import com.mogak.spring.repository.PostImgRepository;
+import com.mogak.spring.repository.PostRepository;
+import com.mogak.spring.repository.UserRepository;
+import com.mogak.spring.service.MogakService;
+import com.mogak.spring.service.PostCommentService;
+import com.mogak.spring.service.PostService;
+import com.mogak.spring.service.StorageService;
+import com.mogak.spring.support.TestFixtureFactory;
+import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
+import com.mogak.spring.web.dto.mogakdto.MogakResponseDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.GetAllNetworkDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.GetPostDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkPostDto;
+import jakarta.persistence.EntityManager;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest
+class ListQueryCountIntegrationTest {
+
+    @Autowired private PostService postService;
+    @Autowired private MogakService mogakService;
+    @Autowired private PostCommentService postCommentService;
+
+    @Autowired private UserRepository userRepository;
+    @Autowired private JobRepository jobRepository;
+    @Autowired private AddressRepository addressRepository;
+    @Autowired private ModaratRepository modaratRepository;
+    @Autowired private MogakCategoryRepository categoryRepository;
+    @Autowired private MogakRepository mogakRepository;
+    @Autowired private JogakRepository jogakRepository;
+    @Autowired private DailyJogakRepository dailyJogakRepository;
+    @Autowired private JogakPeriodRepository jogakPeriodRepository;
+    @Autowired private PostRepository postRepository;
+    @Autowired private PostImgRepository postImgRepository;
+    @Autowired private PostCommentRepository postCommentRepository;
+    @Autowired private FollowRepository followRepository;
+    @Autowired private EntityManager entityManager;
+
+    @MockitoBean private AppleOAuthUserProvider appleOAuthUserProvider;
+    @MockitoBean private StorageService storageService;
+
+    private Statistics statistics;
+    private Job job;
+    private Address address;
+    private MogakCategory category;
+    private LocalDate today;
+
+    @BeforeEach
+    void setUp() {
+        statistics = entityManager.getEntityManagerFactory()
+                .unwrap(SessionFactory.class)
+                .getStatistics();
+        statistics.setStatisticsEnabled(true);
+        job = jobRepository.save(TestFixtureFactory.job("개발/데이터"));
+        address = addressRepository.save(TestFixtureFactory.address("서울특별시"));
+        category = categoryRepository.save(TestFixtureFactory.category(null, "자격증"));
+        today = LocalDate.now();
+    }
+
+    @Test
+    @DisplayName("네트워크 게시글 목록은 게시글 수가 늘어도 쿼리 수가 선형 증가하지 않는다")
+    void networkPostsQueryCountDoesNotGrowWithPostCount() {
+        User viewer = saveUser("viewer-network@test.com", "viewer");
+        User writer = saveUser("writer-network@test.com", "writer");
+        Mogak mogak = saveMogak(writer, "네트워크 모각");
+        savePost(writer, mogak, "one", "thumb-one");
+        savePost(writer, mogak, "two", "thumb-two");
+        savePost(writer, mogak, "three", "thumb-three");
+        flushAndClear();
+
+        QueryResult<Slice<GetAllNetworkDto>> singlePostResult = countQueries(
+                () -> postService.getNetworkPosts(viewer.getId(), 0, 1, "createdAt", address.getName())
+        );
+        QueryResult<Slice<GetAllNetworkDto>> threePostResult = countQueries(
+                () -> postService.getNetworkPosts(viewer.getId(), 0, 3, "createdAt", address.getName())
+        );
+
+        assertThat(singlePostResult.value().getContent())
+                .extracting(GetAllNetworkDto::getContents)
+                .containsExactly("three");
+        assertThat(threePostResult.value().getContent())
+                .extracting(GetAllNetworkDto::getContents)
+                .containsExactly("three", "two", "one");
+        assertThat(threePostResult.value().getContent())
+                .allSatisfy(post -> {
+                    assertThat(post.getUserName()).isEqualTo("writer");
+                    assertThat(post.getUserJob()).isEqualTo(job.getName());
+                    assertThat(post.getImgUrls()).hasSize(1);
+                });
+        assertThat(threePostResult.queryCount()).isEqualTo(singlePostResult.queryCount());
+    }
+
+    @Test
+    @DisplayName("페이스메이커 게시글 목록은 이미지와 댓글 수가 늘어도 쿼리 수가 선형 증가하지 않는다")
+    void pacemakerPostsQueryCountDoesNotGrowWithPostCount() {
+        User viewer = saveUser("viewer-pace@test.com", "viewer");
+        User writer = saveUser("writer-pace@test.com", "writer");
+        followRepository.save(Follow.builder()
+                .fromUser(viewer)
+                .toUser(writer)
+                .build());
+        Mogak mogak = saveMogak(writer, "페이스메이커 모각");
+        savePost(writer, mogak, "one", "thumb-one");
+        savePost(writer, mogak, "two", "thumb-two");
+        savePost(writer, mogak, "three", "thumb-three");
+        flushAndClear();
+
+        QueryResult<List<NetworkPostDto>> singlePostResult = countQueries(
+                () -> postService.getPacemakerPosts(viewer.getId(), 0, 1)
+        );
+        QueryResult<List<NetworkPostDto>> threePostResult = countQueries(
+                () -> postService.getPacemakerPosts(viewer.getId(), 0, 3)
+        );
+
+        assertThat(singlePostResult.value()).hasSize(1);
+        assertThat(threePostResult.value())
+                .extracting(NetworkPostDto::getContents)
+                .containsExactly("three", "two", "one");
+        assertThat(threePostResult.value())
+                .allSatisfy(post -> {
+                    assertThat(post.getUser().getNickname()).isEqualTo("writer");
+                    assertThat(post.getUser().getJob()).isEqualTo(job.getName());
+                    assertThat(post.getImgUrls()).hasSize(1);
+                    assertThat(post.getComments()).hasSize(1);
+                });
+        assertThat(threePostResult.queryCount()).isEqualTo(singlePostResult.queryCount());
+    }
+
+    @Test
+    @DisplayName("모각별 게시글 목록은 게시글 수가 늘어도 쿼리 수가 선형 증가하지 않는다")
+    void mogakPostsQueryCountDoesNotGrowWithPostCount() {
+        User writer = saveUser("writer-mogak-post@test.com", "writer");
+        Mogak mogak = saveMogak(writer, "게시글 모각");
+        savePost(writer, mogak, "one", "thumb-one");
+        savePost(writer, mogak, "two", "thumb-two");
+        savePost(writer, mogak, "three", "thumb-three");
+        flushAndClear();
+
+        QueryResult<Slice<GetPostDto>> singlePostResult = countQueries(
+                () -> postService.getAllPosts(writer.getId(), 0, mogak.getId(), 1)
+        );
+        QueryResult<Slice<GetPostDto>> threePostResult = countQueries(
+                () -> postService.getAllPosts(writer.getId(), 0, mogak.getId(), 3)
+        );
+
+        assertThat(singlePostResult.value().getContent())
+                .extracting(GetPostDto::getContents)
+                .containsExactly("three");
+        assertThat(threePostResult.value().getContent())
+                .extracting(GetPostDto::getContents)
+                .containsExactly("three", "two", "one");
+        assertThat(threePostResult.value().getContent())
+                .allSatisfy(post -> {
+                    assertThat(post.getMogakId()).isEqualTo(mogak.getId());
+                    assertThat(post.getThumbnailUrl()).startsWith("https://example.com/thumb-");
+                });
+        assertThat(threePostResult.queryCount()).isEqualTo(singlePostResult.queryCount());
+    }
+
+    @Test
+    @DisplayName("모각 목록은 모각 수가 늘어도 쿼리 수가 선형 증가하지 않는다")
+    void mogakListQueryCountDoesNotGrowWithMogakCount() {
+        User writer = saveUser("writer-mogak-list@test.com", "writer");
+        Modarat smallModarat = modaratRepository.save(TestFixtureFactory.modarat(null, writer, "작은 모다라트", "#111111"));
+        Modarat largeModarat = modaratRepository.save(TestFixtureFactory.modarat(null, writer, "큰 모다라트", "#222222"));
+        mogakRepository.save(TestFixtureFactory.mogak(null, writer, smallModarat, category, "small-one", "#111111"));
+        mogakRepository.save(TestFixtureFactory.mogak(null, writer, largeModarat, category, "large-one", "#111111"));
+        mogakRepository.save(TestFixtureFactory.mogak(null, writer, largeModarat, category, "large-two", "#222222"));
+        mogakRepository.save(TestFixtureFactory.mogak(null, writer, largeModarat, category, "large-three", "#333333"));
+        flushAndClear();
+
+        QueryResult<MogakResponseDto.GetMogakListDto> singleMogakResult = countQueries(
+                () -> mogakService.getMogakDtoList(writer.getId(), smallModarat.getId())
+        );
+        QueryResult<MogakResponseDto.GetMogakListDto> threeMogakResult = countQueries(
+                () -> mogakService.getMogakDtoList(writer.getId(), largeModarat.getId())
+        );
+
+        assertThat(singleMogakResult.value().getMogaks())
+                .extracting(MogakResponseDto.GetMogakDto::getTitle)
+                .containsExactly("small-one");
+        assertThat(threeMogakResult.value().getMogaks())
+                .extracting(MogakResponseDto.GetMogakDto::getTitle)
+                .containsExactlyInAnyOrder("large-one", "large-two", "large-three");
+        assertThat(threeMogakResult.value().getMogaks())
+                .allSatisfy(mogak -> assertThat(mogak.getBigCategory().getName()).isEqualTo(category.getName()));
+        assertThat(threeMogakResult.queryCount()).isEqualTo(singleMogakResult.queryCount());
+    }
+
+    @Test
+    @DisplayName("조각 목록은 조각과 요일 수가 늘어도 쿼리 수가 선형 증가하지 않는다")
+    void jogakListQueryCountDoesNotGrowWithJogakCount() {
+        User user = saveUser("writer-jogak@test.com", "writer");
+        Mogak smallMogak = saveMogak(user, "작은 조각 모각");
+        Mogak largeMogak = saveMogak(user, "큰 조각 모각");
+        saveJogakWithPeriod(user, smallMogak, "small-one", "MONDAY");
+        saveJogakWithPeriod(user, largeMogak, "large-one", "MONDAY");
+        saveJogakWithPeriod(user, largeMogak, "large-two", "TUESDAY");
+        saveJogakWithPeriod(user, largeMogak, "large-three", "WEDNESDAY");
+        flushAndClear();
+
+        QueryResult<List<JogakResponseDto.GetJogakDto>> singleJogakResult = countQueries(
+                () -> mogakService.getJogaks(user.getId(), smallMogak.getId(), today)
+        );
+        QueryResult<List<JogakResponseDto.GetJogakDto>> threeJogakResult = countQueries(
+                () -> mogakService.getJogaks(user.getId(), largeMogak.getId(), today)
+        );
+
+        assertThat(singleJogakResult.value())
+                .extracting(JogakResponseDto.GetJogakDto::getTitle)
+                .containsExactly("small-one");
+        assertThat(threeJogakResult.value())
+                .extracting(JogakResponseDto.GetJogakDto::getTitle)
+                .containsExactlyInAnyOrder("large-one", "large-two", "large-three");
+        assertThat(threeJogakResult.value())
+                .allSatisfy(jogak -> {
+                    assertThat(jogak.getMogakTitle()).isEqualTo(largeMogak.getTitle());
+                    assertThat(jogak.getCategory()).isEqualTo(category.getName());
+                    assertThat(jogak.getDays()).hasSize(1);
+                });
+        assertThat(threeJogakResult.queryCount()).isEqualTo(singleJogakResult.queryCount());
+    }
+
+    @Test
+    @DisplayName("댓글 목록은 댓글 수가 늘어도 쿼리 수가 선형 증가하지 않는다")
+    void commentListQueryCountDoesNotGrowWithCommentCount() {
+        User writer = saveUser("writer-comment@test.com", "writer");
+        User commenter = saveUser("commenter@test.com", "commenter");
+        Mogak mogak = saveMogak(writer, "댓글 모각");
+        Post smallPost = savePost(writer, mogak, "one", "thumb-one", false);
+        Post largePost = savePost(writer, mogak, "two", "thumb-two", false);
+        saveComment(smallPost, commenter, "small-one");
+        saveComment(largePost, commenter, "large-one");
+        saveComment(largePost, commenter, "large-two");
+        saveComment(largePost, commenter, "large-three");
+        flushAndClear();
+
+        QueryResult<List<PostComment>> singleCommentResult = countQueries(
+                () -> postCommentService.findByPostId(smallPost.getId())
+        );
+        QueryResult<List<PostComment>> threeCommentResult = countQueries(
+                () -> postCommentService.findByPostId(largePost.getId())
+        );
+
+        assertThat(singleCommentResult.value())
+                .extracting(PostComment::getContents)
+                .containsExactly("small-one");
+        assertThat(threeCommentResult.value())
+                .extracting(PostComment::getContents)
+                .containsExactlyInAnyOrder("large-one", "large-two", "large-three");
+        assertThat(threeCommentResult.value())
+                .allSatisfy(comment -> {
+                    assertThat(comment.getPost().getId()).isEqualTo(largePost.getId());
+                    assertThat(comment.getUser().getNickname()).isEqualTo("commenter");
+                });
+        assertThat(threeCommentResult.queryCount()).isEqualTo(singleCommentResult.queryCount());
+    }
+
+    private <T> QueryResult<T> countQueries(QueryAction<T> action) {
+        statistics.clear();
+        T value = action.run();
+        long queryCount = statistics.getPrepareStatementCount();
+        entityManager.clear();
+        return new QueryResult<>(value, queryCount);
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    private User saveUser(String email, String nickname) {
+        return userRepository.save(TestFixtureFactory.user(null, email, nickname, job, address));
+    }
+
+    private Mogak saveMogak(User user, String title) {
+        Modarat modarat = modaratRepository.save(TestFixtureFactory.modarat(null, user, title + " 모다라트", "#111111"));
+        return mogakRepository.save(TestFixtureFactory.mogak(null, user, modarat, category, title, "#222222"));
+    }
+
+    private Post savePost(User writer, Mogak mogak, String contents, String thumbnailName) {
+        return savePost(writer, mogak, contents, thumbnailName, true);
+    }
+
+    private Post savePost(User writer, Mogak mogak, String contents, String thumbnailName, boolean includeComment) {
+        Jogak jogak = jogakRepository.save(TestFixtureFactory.jogak(null, mogak, contents + " 조각", false, today, null, 0));
+        DailyJogak dailyJogak = dailyJogakRepository.save(TestFixtureFactory.dailyJogak(null, jogak, today, DailyJogakStatus.SUCCESS));
+        Post post = postRepository.save(Post.builder()
+                .dailyJogak(dailyJogak)
+                .user(writer)
+                .contents(contents)
+                .postThumbnailUrl("https://example.com/" + thumbnailName + ".png")
+                .viewCnt(0)
+                .build());
+        postImgRepository.save(PostImg.builder()
+                .post(post)
+                .imgName(thumbnailName + ".png")
+                .imgUrl("https://example.com/" + thumbnailName + ".png")
+                .build());
+        postImgRepository.save(PostImg.builder()
+                .post(post)
+                .imgName(contents + ".png")
+                .imgUrl("https://example.com/" + contents + ".png")
+                .build());
+        if (includeComment) {
+            saveComment(post, writer, contents + " 댓글");
+        }
+        return post;
+    }
+
+    private void saveComment(Post post, User user, String contents) {
+        postCommentRepository.save(PostComment.builder()
+                .post(post)
+                .user(user)
+                .contents(contents)
+                .build());
+    }
+
+    private void saveJogakWithPeriod(User user, Mogak mogak, String title, String day) {
+        Jogak jogak = jogakRepository.save(TestFixtureFactory.jogak(null, mogak, title, true, today, null, 0));
+        Period period = TestFixtureFactory.period(day);
+        entityManager.persist(period);
+        jogakPeriodRepository.save(TestFixtureFactory.jogakPeriod(jogak, period));
+        dailyJogakRepository.save(TestFixtureFactory.dailyJogak(null, jogak, today, DailyJogakStatus.PENDING));
+    }
+
+    @FunctionalInterface
+    private interface QueryAction<T> {
+        T run();
+    }
+
+    private record QueryResult<T>(T value, long queryCount) {
+    }
+}

--- a/src/test/java/com/mogak/spring/repository/DailyJogakRepositoryTest.java
+++ b/src/test/java/com/mogak/spring/repository/DailyJogakRepositoryTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 
+import jakarta.persistence.PersistenceUnitUtil;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -58,6 +59,10 @@ class DailyJogakRepositoryTest {
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getTitle()).isEqualTo("문제풀이");
+        PersistenceUnitUtil util = entityManager.getEntityManager()
+                .getEntityManagerFactory()
+                .getPersistenceUnitUtil();
+        assertThat(util.isLoaded(result.get(0), "jogak")).isTrue();
     }
 
     @Test

--- a/src/test/java/com/mogak/spring/repository/JogakRepositoryTest.java
+++ b/src/test/java/com/mogak/spring/repository/JogakRepositoryTest.java
@@ -18,6 +18,7 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 
+import jakarta.persistence.PersistenceUnitUtil;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -119,6 +120,44 @@ class JogakRepositoryTest {
         assertThat(result).extracting(Jogak::getTitle).containsExactly("조회 대상");
         assertThat(result.get(0).getMogak().getTitle()).isEqualTo("정보처리기사");
         assertThat(result.get(0).getCategory().getName()).isEqualTo("자격증");
+    }
+
+    @Test
+    @DisplayName("모각별 조각 그래프 조회는 응답 변환에 필요한 연관을 함께 로딩한다")
+    void findAllByMogakWithFetchGraph() {
+        User user = persistUser("fetch-graph@test.com");
+        Modarat modarat = entityManager.persist(TestFixtureFactory.modarat(null, user, "메인", "#1111"));
+        MogakCategory category = entityManager.persist(TestFixtureFactory.category(null, "자격증"));
+        Mogak mogak = entityManager.persist(TestFixtureFactory.mogak(null, user, modarat, category, "정보처리기사", "#aaaa"));
+        Jogak routineJogak = entityManager.persist(TestFixtureFactory.jogak(null, mogak, "루틴 조각", true, LocalDate.now(), null, 0));
+        Jogak oneTimeJogak = entityManager.persist(TestFixtureFactory.jogak(null, mogak, "일회성 조각", false, LocalDate.now(), null, 0));
+        Period monday = entityManager.persist(TestFixtureFactory.period("MONDAY"));
+        Period tuesday = entityManager.persist(TestFixtureFactory.period("TUESDAY"));
+        entityManager.persist(TestFixtureFactory.jogakPeriod(routineJogak, monday));
+        entityManager.persist(TestFixtureFactory.jogakPeriod(routineJogak, tuesday));
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Jogak> result = jogakRepository.findAllByMogakWithFetchGraph(mogak);
+
+        PersistenceUnitUtil util = entityManager.getEntityManager()
+                .getEntityManagerFactory()
+                .getPersistenceUnitUtil();
+        assertThat(result).extracting(Jogak::getTitle)
+                .containsExactlyInAnyOrder("루틴 조각", "일회성 조각");
+        assertThat(result)
+                .allSatisfy(jogak -> {
+                    assertThat(util.isLoaded(jogak, "mogak")).isTrue();
+                    assertThat(util.isLoaded(jogak, "category")).isTrue();
+                    assertThat(util.isLoaded(jogak, "jogakPeriods")).isTrue();
+                });
+        Jogak fetchedRoutine = result.stream()
+                .filter(jogak -> jogak.getTitle().equals("루틴 조각"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(fetchedRoutine.getPeriods()).containsExactlyInAnyOrder("MONDAY", "TUESDAY");
+        assertThat(fetchedRoutine.getJogakPeriods())
+                .allSatisfy(jogakPeriod -> assertThat(util.isLoaded(jogakPeriod, "period")).isTrue());
     }
 
     private User persistUser(String email) {

--- a/src/test/java/com/mogak/spring/repository/MogakRepositoryTest.java
+++ b/src/test/java/com/mogak/spring/repository/MogakRepositoryTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 
+import jakarta.persistence.PersistenceUnitUtil;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -42,8 +43,12 @@ class MogakRepositoryTest {
 
         List<Mogak> result = mogakRepository.findAllByModaratId(firstModarat.getId());
 
+        PersistenceUnitUtil util = entityManager.getEntityManager()
+                .getEntityManagerFactory()
+                .getPersistenceUnitUtil();
         assertThat(result).extracting(Mogak::getTitle).containsExactly("정보처리기사");
         assertThat(result).doesNotContain(second);
+        assertThat(util.isLoaded(result.get(0), "bigCategory")).isTrue();
         assertThat(first.getId()).isNotNull();
     }
 

--- a/src/test/java/com/mogak/spring/repository/PostCommentRepositoryTest.java
+++ b/src/test/java/com/mogak/spring/repository/PostCommentRepositoryTest.java
@@ -18,7 +18,9 @@ import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 
+import jakarta.persistence.PersistenceUnitUtil;
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,6 +52,69 @@ class PostCommentRepositoryTest {
         entityManager.clear();
 
         assertThat(postCommentRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("게시글 댓글 목록 조회는 작성자를 함께 로딩한다")
+    void findActiveAllByPostFetchesUser() {
+        User user = persistUser();
+        Post post = persistPost(user);
+        entityManager.persist(PostComment.builder()
+                .post(post)
+                .user(user)
+                .contents("댓글")
+                .build());
+        entityManager.flush();
+        entityManager.clear();
+
+        List<PostComment> result = postCommentRepository.findActiveAllByPost(post);
+
+        PersistenceUnitUtil util = entityManager.getEntityManager()
+                .getEntityManagerFactory()
+                .getPersistenceUnitUtil();
+        assertThat(result).hasSize(1);
+        assertThat(util.isLoaded(result.get(0), "user")).isTrue();
+    }
+
+    @Test
+    @DisplayName("게시글 ID 목록으로 활성 댓글을 조회하면 게시글과 작성자를 함께 로딩한다")
+    void findActiveAllByPostIdInWithUserFetchesPostAndUser() {
+        User user = persistUser();
+        Post firstPost = persistPost(user);
+        Post secondPost = persistPost(user);
+        Post otherPost = persistPost(user);
+        entityManager.persist(PostComment.builder()
+                .post(firstPost)
+                .user(user)
+                .contents("첫 번째 댓글")
+                .build());
+        entityManager.persist(PostComment.builder()
+                .post(secondPost)
+                .user(user)
+                .contents("두 번째 댓글")
+                .build());
+        entityManager.persist(PostComment.builder()
+                .post(otherPost)
+                .user(user)
+                .contents("제외 댓글")
+                .build());
+        entityManager.flush();
+        entityManager.clear();
+
+        List<PostComment> result = postCommentRepository.findActiveAllByPostIdInWithUser(
+                List.of(firstPost.getId(), secondPost.getId())
+        );
+
+        PersistenceUnitUtil util = entityManager.getEntityManager()
+                .getEntityManagerFactory()
+                .getPersistenceUnitUtil();
+        assertThat(result).extracting(PostComment::getContents)
+                .containsExactlyInAnyOrder("첫 번째 댓글", "두 번째 댓글");
+        assertThat(result)
+                .allSatisfy(comment -> {
+                    assertThat(util.isLoaded(comment, "post")).isTrue();
+                    assertThat(util.isLoaded(comment, "user")).isTrue();
+                });
     }
 
     private User persistUser() {

--- a/src/test/java/com/mogak/spring/service/MogakServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/MogakServiceImplTest.java
@@ -247,7 +247,7 @@ class MogakServiceImplTest {
         TestFixtureFactory.attachJogaks(mogak, List.of(active, expired));
         when(userRepository.findActiveById(1L)).thenReturn(Optional.of(user));
         when(mogakRepository.findActiveById(2L)).thenReturn(Optional.of(mogak));
-        when(jogakRepository.findAllByMogak(mogak)).thenReturn(List.of(active));
+        when(jogakRepository.findAllByMogakWithFetchGraph(mogak)).thenReturn(List.of(active));
         when(dailyJogakRepository.findDailyJogaks(user, day)).thenReturn(List.of(dailyJogak));
 
         List<JogakResponseDto.GetJogakDto> result = mogakService.getJogaks(1L, 2L, day);
@@ -255,5 +255,6 @@ class MogakServiceImplTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getJogakId()).isEqualTo(10L);
         assertThat(result.get(0).getIsAlreadyAdded()).isTrue();
+        verify(jogakRepository).findAllByMogakWithFetchGraph(mogak);
     }
 }

--- a/src/test/java/com/mogak/spring/web/controller/NetworkControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/NetworkControllerTest.java
@@ -9,6 +9,7 @@ import com.mogak.spring.service.PostLikeService;
 import com.mogak.spring.service.PostService;
 import com.mogak.spring.support.SecurityContextTestHelper;
 import com.mogak.spring.web.dto.postdto.PostLikeRequestDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.GetAllNetworkDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,12 +18,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,6 +37,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -121,6 +128,46 @@ class NetworkControllerTest {
                 .andExpect(status().isNotFound());
         mockMvc.perform(delete("/api/posts/{postId}/like", 10L))
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("네트워크 게시글 조회는 기존 Slice DTO JSON 계약을 유지한다")
+    void getAllPostsReturnsSliceDtoContract() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "user@test.com", "ROLE_USER");
+        GetAllNetworkDto post = GetAllNetworkDto.builder()
+                .postId(20L)
+                .userName("writer")
+                .userJob("개발/데이터")
+                .contents("네트워크 회고")
+                .imgUrls(List.of("https://example.com/body.png"))
+                .commentCnt(2)
+                .likeCnt(5)
+                .build();
+        Slice<GetAllNetworkDto> posts = new SliceImpl<>(List.of(post), PageRequest.of(0, 10), true);
+        when(postService.getNetworkPosts(7L, 0, 10, "createdAt", "서울특별시")).thenReturn(posts);
+
+        mockMvc.perform(get("/api/posts")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .param("sort", "createdAt")
+                        .param("address", "서울특별시"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value("success"))
+                .andExpect(jsonPath("$.result.content[0].postId").value(20))
+                .andExpect(jsonPath("$.result.content[0].userName").value("writer"))
+                .andExpect(jsonPath("$.result.content[0].userJob").value("개발/데이터"))
+                .andExpect(jsonPath("$.result.content[0].contents").value("네트워크 회고"))
+                .andExpect(jsonPath("$.result.content[0].imgUrls[0]").value("https://example.com/body.png"))
+                .andExpect(jsonPath("$.result.content[0].commentCnt").value(2))
+                .andExpect(jsonPath("$.result.content[0].likeCnt").value(5))
+                .andExpect(jsonPath("$.result.size").value(10))
+                .andExpect(jsonPath("$.result.number").value(0))
+                .andExpect(jsonPath("$.result.numberOfElements").value(1))
+                .andExpect(jsonPath("$.result.first").value(true))
+                .andExpect(jsonPath("$.result.last").value(false));
+
+        verify(postService).getNetworkPosts(7L, 0, 10, "createdAt", "서울특별시");
     }
 
     private PostLikeRequestDto.LikeDto likeRequest(Long postId) {

--- a/src/test/java/com/mogak/spring/web/controller/PostControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/PostControllerTest.java
@@ -15,6 +15,7 @@ import com.mogak.spring.support.SecurityContextTestHelper;
 import com.mogak.spring.support.TestFixtureFactory;
 import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
 import com.mogak.spring.web.dto.postdto.PostRequestDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.GetPostDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
@@ -276,7 +278,7 @@ class PostControllerTest {
     @DisplayName("모각별 게시글 조회는 인증 사용자의 id를 서비스에 전달한다")
     void getPostListUsesAuthenticatedUserId() throws Exception {
         SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
-        Slice<Post> posts = new SliceImpl<>(List.of());
+        Slice<GetPostDto> posts = new SliceImpl<>(List.of());
         when(postService.getAllPosts(7L, 0, 1L, 10)).thenReturn(posts);
 
         mockMvc.perform(get("/api/mogaks/{mogakId}/posts", 1L)
@@ -285,6 +287,44 @@ class PostControllerTest {
                 .andExpect(status().isOk());
 
         verify(postService).getAllPosts(7L, 0, 1L, 10);
+    }
+
+    @Test
+    @DisplayName("모각별 게시글 조회는 기존 Slice DTO JSON 계약을 유지한다")
+    void getPostListReturnsSliceDtoContract() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
+        GetPostDto post = GetPostDto.builder()
+                .postId(11L)
+                .mogakId(1L)
+                .jogakId(2L)
+                .dailyJogakId(3L)
+                .targetDate(LocalDate.of(2026, 4, 21))
+                .contents("오늘 회고")
+                .thumbnailUrl("https://example.com/thumb.png")
+                .likeCnt(4)
+                .build();
+        Slice<GetPostDto> posts = new SliceImpl<>(List.of(post), PageRequest.of(0, 10), true);
+        when(postService.getAllPosts(7L, 0, 1L, 10)).thenReturn(posts);
+
+        mockMvc.perform(get("/api/mogaks/{mogakId}/posts", 1L)
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value("success"))
+                .andExpect(jsonPath("$.result.content[0].postId").value(11))
+                .andExpect(jsonPath("$.result.content[0].mogakId").value(1))
+                .andExpect(jsonPath("$.result.content[0].jogakId").value(2))
+                .andExpect(jsonPath("$.result.content[0].dailyJogakId").value(3))
+                .andExpect(jsonPath("$.result.content[0].targetDate").value("2026-04-21"))
+                .andExpect(jsonPath("$.result.content[0].contents").value("오늘 회고"))
+                .andExpect(jsonPath("$.result.content[0].thumbnailUrl").value("https://example.com/thumb.png"))
+                .andExpect(jsonPath("$.result.content[0].likeCnt").value(4))
+                .andExpect(jsonPath("$.result.size").value(10))
+                .andExpect(jsonPath("$.result.number").value(0))
+                .andExpect(jsonPath("$.result.numberOfElements").value(1))
+                .andExpect(jsonPath("$.result.first").value(true))
+                .andExpect(jsonPath("$.result.last").value(false));
     }
 
     @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,6 +20,7 @@ spring:
       hibernate:
         #        show_sql: true
         format_sql: true
+        generate_statistics: true
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 해결하려던 문제 혹은 구현하려는 기능

Closes #139

주요 목록 API에서 응답 DTO 조립 중 lazy association 접근으로 N+1이 발생할 수 있는 지점을 점검하고 조회 전략을 명시적으로 보완했습니다.

- 네트워크 게시글/페이스메이커 게시글/모각별 게시글/모각 목록/조각 목록/댓글 목록의 조회 전략 보완
- to-one 연관은 fetch join으로 명시 로딩
- 페이징 목록의 컬렉션 데이터는 루트 id 기반 배치 조회 후 서비스 계층에서 그룹핑
- `Slice<DTO>` JSON 응답 계약 회귀를 막는 MockMvc 테스트 추가
- 조회 전략 및 N+1 검증 기준 문서 추가

참고:
- Spring Data `Slice` 응답 구조를 전용 DTO로 분리하는 후속 개선은 #154로 분리했습니다.

## 테스트 시나리오

- `sh gradlew test --tests com.mogak.spring.repository.MogakRepositoryTest --tests com.mogak.spring.integration.ListQueryCountIntegrationTest --rerun-tasks`
- `sh gradlew test --tests com.mogak.spring.web.controller.PostControllerTest --tests com.mogak.spring.web.controller.NetworkControllerTest --rerun-tasks`
- `sh gradlew test --rerun-tasks`

검증 내용:
- 주요 목록 API가 데이터 수 증가에 따라 쿼리 수가 선형 증가하지 않는지 확인
- repository fetch 전략이 응답 변환에 필요한 연관을 로딩하는지 확인
- `BaseResponse.result.content[]` 및 Slice 메타데이터 JSON 계약 확인

## 관련 이슈

- #139
- 후속 이슈: #154
