### PR TITLE
refactor(#154): Slice 응답 계약을 전용 DTO로 분리

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 
 ## 빠른 링크
 - [루트 가이드](../AGENTS.md)
+- [게시글 목록 API](api/post-list.md)
 - [소셜 로그인 API](api/social-login.md)
 - [Claude Compatibility](../CLAUDE.md)
 - [프로젝트 규약](operations/policies/PROJECT_CONVENTIONS.md)

--- a/docs/api/post-list.md
+++ b/docs/api/post-list.md
@@ -1,0 +1,42 @@
+# Post List API
+
+이 문서는 게시글 목록 API의 응답 계약을 정리한다.
+
+## Endpoints
+
+- `GET /api/mogaks/{mogakId}/posts`
+- `GET /api/posts`
+
+## Response
+
+목록 응답은 Spring Data `Slice` 직렬화 구조를 직접 노출하지 않는다.
+
+```json
+{
+  "time": "2026-04-28 12:00:00",
+  "status": "OK",
+  "code": "SU",
+  "message": "성공",
+  "result": {
+    "items": [],
+    "page": 0,
+    "size": 10,
+    "hasNext": true
+  }
+}
+```
+
+`result` 필드:
+
+| Field | Meaning |
+| --- | --- |
+| `items` | 현재 페이지의 게시글 응답 DTO 목록 |
+| `page` | 요청 page 값 |
+| `size` | 요청 size 값 |
+| `hasNext` | 다음 page 존재 여부 |
+
+## Contract Notes
+
+- `result.content`, `result.number`, `result.numberOfElements`, `result.first`, `result.last`는 응답 계약이 아니다.
+- `page`는 0부터 시작한다.
+- `GET /api/posts`의 `address`가 생략되면 서버는 기존 동작대로 인증 사용자의 거주지를 사용한다.

--- a/src/main/java/com/mogak/spring/service/PostService.java
+++ b/src/main/java/com/mogak/spring/service/PostService.java
@@ -4,9 +4,8 @@ import com.mogak.spring.domain.post.Post;
 import com.mogak.spring.domain.post.PostImg;
 import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
 import com.mogak.spring.web.dto.postdto.PostRequestDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto.GetAllNetworkDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto.GetPostDto;
-import org.springframework.data.domain.Slice;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkListDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.PostListDto;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -19,12 +18,12 @@ public interface PostService {
     void validateCreateAccess(Long userId, PostRequestDto.CreatePostDto request, List<MultipartFile> multipartFile, Long jogakId);
     Post create(Long userId, PostRequestDto.CreatePostDto request, List<PostImgRequestDto.CreatePostImgDto> postImgDtoList, Long jogakId);
     Post getByJogakAndTargetDate(Long userId, Long jogakId, LocalDate targetDate);
-    Slice<GetPostDto> getAllPosts(Long userId, int page, Long mogakId, int size);
+    PostListDto getAllPosts(Long userId, int page, Long mogakId, int size);
     Post findById(Long userId, Long postId);
     Post update(Long userId, Long postId, PostRequestDto.UpdatePostDto request);
     void delete(Long userId, Long postId);
     List<NetworkPostDto> getPacemakerPosts(Long userId, int cursor, int size);
-    Slice<GetAllNetworkDto> getNetworkPosts(Long userId, int page, int size, String sort, String address);
+    NetworkListDto getNetworkPosts(Long userId, int page, int size, String sort, String address);
     List<String> findImgUrlByPost(Long postId);
     List<Long> findActiveCommentIds(Post post);
     List<String> findNotThumbnailImg(Post post);

--- a/src/main/java/com/mogak/spring/service/PostServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/PostServiceImpl.java
@@ -18,7 +18,9 @@ import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
 import com.mogak.spring.web.dto.postdto.PostRequestDto;
 import com.mogak.spring.web.dto.postdto.PostResponseDto.GetAllNetworkDto;
 import com.mogak.spring.web.dto.postdto.PostResponseDto.GetPostDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkListDto;
 import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkPostDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.PostListDto;
 import com.mogak.spring.web.dto.commentdto.CommentResponseDto;
 import com.mogak.spring.web.dto.userdto.UserResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -116,12 +118,13 @@ public class PostServiceImpl implements PostService {
 
     //회고록 조회 - 무한 스크롤
     @Override
-    public Slice<GetPostDto> getAllPosts(Long userId, int page, Long mogakId, int size) {
+    public PostListDto getAllPosts(Long userId, int page, Long mogakId, int size) {
         getOwnedMogak(userId, mogakId);
         Pageable pageable = PageRequest.of(page, size);
 
-        return postRepository.findAllPosts(mogakId, pageable)
+        Slice<GetPostDto> posts = postRepository.findAllPosts(mogakId, pageable)
                 .map(GetPostDto::from);
+        return PostListDto.of(posts.getContent(), page, size, posts.hasNext());
     }
 
     //회고록 상세 조회 + 댓글, 이미지 같이 보이게
@@ -195,7 +198,7 @@ public class PostServiceImpl implements PostService {
 
     //전체 네트워킹 조회 - 이미지 썸네일 제외 반환
     @Override
-    public Slice<GetAllNetworkDto> getNetworkPosts(Long userId, int page, int size, String sort, String address /*List<String> categoryList,*/){
+    public NetworkListDto getNetworkPosts(Long userId, int page, int size, String sort, String address /*List<String> categoryList,*/){
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         if(address == null){
@@ -204,7 +207,9 @@ public class PostServiceImpl implements PostService {
         Pageable pageable = PageRequest.of(page, size);
         Slice<Post> posts = postRepository.findNetworkPosts(address, sort, pageable);
         Map<Long, List<PostImg>> imagesByPostId = groupImagesByPostId(extractPostIds(posts.getContent()));
-        return posts.map(post -> GetAllNetworkDto.from(post, findNotThumbnailImgUrls(post, imagesByPostId)));
+        List<GetAllNetworkDto> postDtos = posts.map(post -> GetAllNetworkDto.from(post, findNotThumbnailImgUrls(post, imagesByPostId)))
+                .getContent();
+        return NetworkListDto.of(postDtos, page, size, posts.hasNext());
     }
 
     private List<Long> extractPostIds(List<Post> posts) {

--- a/src/main/java/com/mogak/spring/web/controller/NetworkController.java
+++ b/src/main/java/com/mogak/spring/web/controller/NetworkController.java
@@ -7,7 +7,7 @@ import com.mogak.spring.jwt.AuthenticatedUser;
 import com.mogak.spring.service.PostLikeService;
 import com.mogak.spring.service.PostService;
 import com.mogak.spring.web.dto.postdto.PostLikeRequestDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkListDto;
 import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkPostDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,7 +19,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -90,12 +89,12 @@ public class NetworkController {
                     @ApiResponse(responseCode = "500", description = "서버 오류"),
             })
     @GetMapping("/api/posts")
-    public ResponseEntity<BaseResponse<Slice<PostResponseDto.GetAllNetworkDto>>> getALlPosts(
+    public ResponseEntity<BaseResponse<NetworkListDto>> getALlPosts(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
             @RequestParam(value = "page", defaultValue = "0") int page, @RequestParam(value = "size") int size,
             @RequestParam(value = "sort", defaultValue = "createdAt", required = false) String sort, @RequestParam(value = "address", required = false) String address
             /*@RequestParam(value = "category", defaultValue="all", required = false) List<String> categoryList,*/) {
-        Slice<PostResponseDto.GetAllNetworkDto> posts = postService.getNetworkPosts(authenticatedUser.getUserId(), page, size, sort, address);
+        NetworkListDto posts = postService.getNetworkPosts(authenticatedUser.getUserId(), page, size, sort, address);
         return ResponseEntity.ok(new BaseResponse<>(posts));
     }
 

--- a/src/main/java/com/mogak/spring/web/controller/PostController.java
+++ b/src/main/java/com/mogak/spring/web/controller/PostController.java
@@ -19,7 +19,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -89,11 +88,11 @@ public class PostController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @GetMapping("/api/mogaks/{mogakId}/posts")
-    public ResponseEntity<BaseResponse<Slice<GetPostDto>>> getPostList(@PathVariable Long mogakId,
-                                                                       @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
-                                                                       @RequestParam(value = "page", defaultValue = "0") int page,
-                                                                       @RequestParam(value = "size") int size) {
-        Slice<GetPostDto> posts = postService.getAllPosts(authenticatedUser.getUserId(), page, mogakId, size);
+    public ResponseEntity<BaseResponse<PostListDto>> getPostList(@PathVariable Long mogakId,
+                                                                 @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                                 @RequestParam(value = "page", defaultValue = "0") int page,
+                                                                 @RequestParam(value = "size") int size) {
+        PostListDto posts = postService.getAllPosts(authenticatedUser.getUserId(), page, mogakId, size);
         return ResponseEntity.ok(new BaseResponse<>(posts));
     }
 

--- a/src/main/java/com/mogak/spring/web/dto/postdto/PostResponseDto.java
+++ b/src/main/java/com/mogak/spring/web/dto/postdto/PostResponseDto.java
@@ -101,12 +101,13 @@ public class PostResponseDto {
     }
 
     public record PostListDto(
-            List<PostResponseDto.GetPostDto> postDtoList,
-            @JsonProperty("hasNext") boolean hasNext,
-            Integer size
+            List<PostResponseDto.GetPostDto> items,
+            Integer page,
+            Integer size,
+            @JsonProperty("hasNext") boolean hasNext
     ) {
-        public static PostListDto of(List<PostResponseDto.GetPostDto> postDtoList, boolean hasNext, Integer size) {
-            return new PostListDto(postDtoList, hasNext, size);
+        public static PostListDto of(List<PostResponseDto.GetPostDto> items, Integer page, Integer size, boolean hasNext) {
+            return new PostListDto(items, page, size, hasNext);
         }
     }
 
@@ -235,12 +236,13 @@ public class PostResponseDto {
     }
 
     public record NetworkListDto(
-            List<PostResponseDto.GetAllNetworkDto> postDtoList,
-            @JsonProperty("hasNext") boolean hasNext,
-            Integer size
+            List<PostResponseDto.GetAllNetworkDto> items,
+            Integer page,
+            Integer size,
+            @JsonProperty("hasNext") boolean hasNext
     ) {
-        public static NetworkListDto of(List<PostResponseDto.GetAllNetworkDto> postDtoList, boolean hasNext, Integer size) {
-            return new NetworkListDto(postDtoList, hasNext, size);
+        public static NetworkListDto of(List<PostResponseDto.GetAllNetworkDto> items, Integer page, Integer size, boolean hasNext) {
+            return new NetworkListDto(items, page, size, hasNext);
         }
     }
 }

--- a/src/test/java/com/mogak/spring/integration/ListQueryCountIntegrationTest.java
+++ b/src/test/java/com/mogak/spring/integration/ListQueryCountIntegrationTest.java
@@ -37,7 +37,9 @@ import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
 import com.mogak.spring.web.dto.mogakdto.MogakResponseDto;
 import com.mogak.spring.web.dto.postdto.PostResponseDto.GetAllNetworkDto;
 import com.mogak.spring.web.dto.postdto.PostResponseDto.GetPostDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkListDto;
 import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkPostDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.PostListDto;
 import jakarta.persistence.EntityManager;
 import org.hibernate.SessionFactory;
 import org.hibernate.stat.Statistics;
@@ -46,7 +48,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
@@ -112,20 +113,20 @@ class ListQueryCountIntegrationTest {
         savePost(writer, mogak, "three", "thumb-three");
         flushAndClear();
 
-        QueryResult<Slice<GetAllNetworkDto>> singlePostResult = countQueries(
+        QueryResult<NetworkListDto> singlePostResult = countQueries(
                 () -> postService.getNetworkPosts(viewer.getId(), 0, 1, "createdAt", address.getName())
         );
-        QueryResult<Slice<GetAllNetworkDto>> threePostResult = countQueries(
+        QueryResult<NetworkListDto> threePostResult = countQueries(
                 () -> postService.getNetworkPosts(viewer.getId(), 0, 3, "createdAt", address.getName())
         );
 
-        assertThat(singlePostResult.value().getContent())
+        assertThat(singlePostResult.value().items())
                 .extracting(GetAllNetworkDto::contents)
                 .containsExactly("three");
-        assertThat(threePostResult.value().getContent())
+        assertThat(threePostResult.value().items())
                 .extracting(GetAllNetworkDto::contents)
                 .containsExactly("three", "two", "one");
-        assertThat(threePostResult.value().getContent())
+        assertThat(threePostResult.value().items())
                 .allSatisfy(post -> {
                     assertThat(post.userName()).isEqualTo("writer");
                     assertThat(post.userJob()).isEqualTo(job.getName());
@@ -180,20 +181,20 @@ class ListQueryCountIntegrationTest {
         savePost(writer, mogak, "three", "thumb-three");
         flushAndClear();
 
-        QueryResult<Slice<GetPostDto>> singlePostResult = countQueries(
+        QueryResult<PostListDto> singlePostResult = countQueries(
                 () -> postService.getAllPosts(writer.getId(), 0, mogak.getId(), 1)
         );
-        QueryResult<Slice<GetPostDto>> threePostResult = countQueries(
+        QueryResult<PostListDto> threePostResult = countQueries(
                 () -> postService.getAllPosts(writer.getId(), 0, mogak.getId(), 3)
         );
 
-        assertThat(singlePostResult.value().getContent())
+        assertThat(singlePostResult.value().items())
                 .extracting(GetPostDto::contents)
                 .containsExactly("three");
-        assertThat(threePostResult.value().getContent())
+        assertThat(threePostResult.value().items())
                 .extracting(GetPostDto::contents)
                 .containsExactly("three", "two", "one");
-        assertThat(threePostResult.value().getContent())
+        assertThat(threePostResult.value().items())
                 .allSatisfy(post -> {
                     assertThat(post.mogakId()).isEqualTo(mogak.getId());
                     assertThat(post.thumbnailUrl()).startsWith("https://example.com/thumb-");

--- a/src/test/java/com/mogak/spring/service/PostServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/PostServiceImplTest.java
@@ -5,6 +5,8 @@ import com.mogak.spring.domain.post.Post;
 import com.mogak.spring.domain.post.PostComment;
 import com.mogak.spring.domain.post.PostImg;
 import com.mogak.spring.domain.jogak.DailyJogakStatus;
+import com.mogak.spring.domain.user.Address;
+import com.mogak.spring.domain.user.Job;
 import com.mogak.spring.domain.user.User;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.repository.*;
@@ -12,6 +14,8 @@ import com.mogak.spring.support.ErrorCodeAssertions;
 import com.mogak.spring.support.TestFixtureFactory;
 import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
 import com.mogak.spring.web.dto.postdto.PostRequestDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkListDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.PostListDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,7 +23,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -28,6 +34,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
@@ -209,6 +216,50 @@ class PostServiceImplTest {
 
         ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PERMISSION);
         verify(postRepository, never()).findAllPosts(anyLong(), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("모각별 게시글 목록은 repository Slice를 전용 목록 DTO로 변환한다")
+    void getAllPostsReturnsDedicatedListDto() {
+        User owner = user(1L, "owner@test.com");
+        Mogak mogak = mogak(10L, owner);
+        Post post = post(20L, owner);
+
+        when(mogakRepository.findActiveById(10L)).thenReturn(Optional.of(mogak));
+        when(postRepository.findAllPosts(10L, PageRequest.of(0, 10)))
+                .thenReturn(new SliceImpl<>(List.of(post), PageRequest.of(0, 10), true));
+
+        PostListDto result = postService.getAllPosts(1L, 0, 10L, 10);
+
+        assertThat(result.items())
+                .extracting("postId", "contents", "thumbnailUrl")
+                .containsExactly(tuple(20L, "content", "https://example.com/thumb.png"));
+        assertThat(result.page()).isZero();
+        assertThat(result.size()).isEqualTo(10);
+        assertThat(result.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("네트워크 게시글 목록은 repository Slice를 전용 목록 DTO로 변환한다")
+    void getNetworkPostsReturnsDedicatedListDto() {
+        Address address = TestFixtureFactory.address("서울특별시");
+        Job job = TestFixtureFactory.job("개발/데이터");
+        User viewer = TestFixtureFactory.user(1L, "viewer@test.com", "viewer", job, address);
+        User writer = TestFixtureFactory.user(2L, "writer@test.com", "writer", job, address);
+        Post post = post(20L, writer);
+
+        when(userRepository.findActiveById(1L)).thenReturn(Optional.of(viewer));
+        when(postRepository.findNetworkPosts("서울특별시", "createdAt", PageRequest.of(0, 10)))
+                .thenReturn(new SliceImpl<>(List.of(post), PageRequest.of(0, 10), true));
+
+        NetworkListDto result = postService.getNetworkPosts(1L, 0, 10, "createdAt", "서울특별시");
+
+        assertThat(result.items())
+                .extracting("postId", "userName", "userJob", "contents")
+                .containsExactly(tuple(20L, "writer", "개발/데이터", "content"));
+        assertThat(result.page()).isZero();
+        assertThat(result.size()).isEqualTo(10);
+        assertThat(result.hasNext()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/mogak/spring/web/controller/NetworkControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/NetworkControllerTest.java
@@ -10,6 +10,7 @@ import com.mogak.spring.service.PostService;
 import com.mogak.spring.support.SecurityContextTestHelper;
 import com.mogak.spring.web.dto.postdto.PostLikeRequestDto;
 import com.mogak.spring.web.dto.postdto.PostResponseDto.GetAllNetworkDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkListDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,9 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -130,8 +128,8 @@ class NetworkControllerTest {
     }
 
     @Test
-    @DisplayName("네트워크 게시글 조회는 기존 Slice DTO JSON 계약을 유지한다")
-    void getAllPostsReturnsSliceDtoContract() throws Exception {
+    @DisplayName("네트워크 게시글 조회는 전용 목록 DTO JSON 계약을 반환한다")
+    void getAllPostsReturnsDedicatedListDtoContract() throws Exception {
         SecurityContextTestHelper.setAuthentication(7L, "user@test.com", "ROLE_USER");
         GetAllNetworkDto post = GetAllNetworkDto.of(
                 20L,
@@ -142,7 +140,7 @@ class NetworkControllerTest {
                 2,
                 5
         );
-        Slice<GetAllNetworkDto> posts = new SliceImpl<>(List.of(post), PageRequest.of(0, 10), true);
+        NetworkListDto posts = NetworkListDto.of(List.of(post), 0, 10, true);
         when(postService.getNetworkPosts(7L, 0, 10, "createdAt", "서울특별시")).thenReturn(posts);
 
         mockMvc.perform(get("/api/posts")
@@ -153,18 +151,21 @@ class NetworkControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value("success"))
-                .andExpect(jsonPath("$.result.content[0].postId").value(20))
-                .andExpect(jsonPath("$.result.content[0].userName").value("writer"))
-                .andExpect(jsonPath("$.result.content[0].userJob").value("개발/데이터"))
-                .andExpect(jsonPath("$.result.content[0].contents").value("네트워크 회고"))
-                .andExpect(jsonPath("$.result.content[0].imgUrls[0]").value("https://example.com/body.png"))
-                .andExpect(jsonPath("$.result.content[0].commentCnt").value(2))
-                .andExpect(jsonPath("$.result.content[0].likeCnt").value(5))
+                .andExpect(jsonPath("$.result.items[0].postId").value(20))
+                .andExpect(jsonPath("$.result.items[0].userName").value("writer"))
+                .andExpect(jsonPath("$.result.items[0].userJob").value("개발/데이터"))
+                .andExpect(jsonPath("$.result.items[0].contents").value("네트워크 회고"))
+                .andExpect(jsonPath("$.result.items[0].imgUrls[0]").value("https://example.com/body.png"))
+                .andExpect(jsonPath("$.result.items[0].commentCnt").value(2))
+                .andExpect(jsonPath("$.result.items[0].likeCnt").value(5))
+                .andExpect(jsonPath("$.result.page").value(0))
                 .andExpect(jsonPath("$.result.size").value(10))
-                .andExpect(jsonPath("$.result.number").value(0))
-                .andExpect(jsonPath("$.result.numberOfElements").value(1))
-                .andExpect(jsonPath("$.result.first").value(true))
-                .andExpect(jsonPath("$.result.last").value(false));
+                .andExpect(jsonPath("$.result.hasNext").value(true))
+                .andExpect(jsonPath("$.result.content").doesNotExist())
+                .andExpect(jsonPath("$.result.number").doesNotExist())
+                .andExpect(jsonPath("$.result.numberOfElements").doesNotExist())
+                .andExpect(jsonPath("$.result.first").doesNotExist())
+                .andExpect(jsonPath("$.result.last").doesNotExist());
 
         verify(postService).getNetworkPosts(7L, 0, 10, "createdAt", "서울특별시");
     }

--- a/src/test/java/com/mogak/spring/web/controller/PostControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/PostControllerTest.java
@@ -16,6 +16,7 @@ import com.mogak.spring.support.TestFixtureFactory;
 import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
 import com.mogak.spring.web.dto.postdto.PostRequestDto;
 import com.mogak.spring.web.dto.postdto.PostResponseDto.GetPostDto;
+import com.mogak.spring.web.dto.postdto.PostResponseDto.PostListDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,9 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -276,7 +274,7 @@ class PostControllerTest {
     @DisplayName("모각별 게시글 조회는 인증 사용자의 id를 서비스에 전달한다")
     void getPostListUsesAuthenticatedUserId() throws Exception {
         SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
-        Slice<GetPostDto> posts = new SliceImpl<>(List.of());
+        PostListDto posts = PostListDto.of(List.of(), 0, 10, false);
         when(postService.getAllPosts(7L, 0, 1L, 10)).thenReturn(posts);
 
         mockMvc.perform(get("/api/mogaks/{mogakId}/posts", 1L)
@@ -288,8 +286,8 @@ class PostControllerTest {
     }
 
     @Test
-    @DisplayName("모각별 게시글 조회는 기존 Slice DTO JSON 계약을 유지한다")
-    void getPostListReturnsSliceDtoContract() throws Exception {
+    @DisplayName("모각별 게시글 조회는 전용 목록 DTO JSON 계약을 반환한다")
+    void getPostListReturnsDedicatedListDtoContract() throws Exception {
         SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
         GetPostDto post = GetPostDto.of(
                 11L,
@@ -301,7 +299,7 @@ class PostControllerTest {
                 "https://example.com/thumb.png",
                 4
         );
-        Slice<GetPostDto> posts = new SliceImpl<>(List.of(post), PageRequest.of(0, 10), true);
+        PostListDto posts = PostListDto.of(List.of(post), 0, 10, true);
         when(postService.getAllPosts(7L, 0, 1L, 10)).thenReturn(posts);
 
         mockMvc.perform(get("/api/mogaks/{mogakId}/posts", 1L)
@@ -310,19 +308,22 @@ class PostControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value("success"))
-                .andExpect(jsonPath("$.result.content[0].postId").value(11))
-                .andExpect(jsonPath("$.result.content[0].mogakId").value(1))
-                .andExpect(jsonPath("$.result.content[0].jogakId").value(2))
-                .andExpect(jsonPath("$.result.content[0].dailyJogakId").value(3))
-                .andExpect(jsonPath("$.result.content[0].targetDate").value("2026-04-21"))
-                .andExpect(jsonPath("$.result.content[0].contents").value("오늘 회고"))
-                .andExpect(jsonPath("$.result.content[0].thumbnailUrl").value("https://example.com/thumb.png"))
-                .andExpect(jsonPath("$.result.content[0].likeCnt").value(4))
+                .andExpect(jsonPath("$.result.items[0].postId").value(11))
+                .andExpect(jsonPath("$.result.items[0].mogakId").value(1))
+                .andExpect(jsonPath("$.result.items[0].jogakId").value(2))
+                .andExpect(jsonPath("$.result.items[0].dailyJogakId").value(3))
+                .andExpect(jsonPath("$.result.items[0].targetDate").value("2026-04-21"))
+                .andExpect(jsonPath("$.result.items[0].contents").value("오늘 회고"))
+                .andExpect(jsonPath("$.result.items[0].thumbnailUrl").value("https://example.com/thumb.png"))
+                .andExpect(jsonPath("$.result.items[0].likeCnt").value(4))
+                .andExpect(jsonPath("$.result.page").value(0))
                 .andExpect(jsonPath("$.result.size").value(10))
-                .andExpect(jsonPath("$.result.number").value(0))
-                .andExpect(jsonPath("$.result.numberOfElements").value(1))
-                .andExpect(jsonPath("$.result.first").value(true))
-                .andExpect(jsonPath("$.result.last").value(false));
+                .andExpect(jsonPath("$.result.hasNext").value(true))
+                .andExpect(jsonPath("$.result.content").doesNotExist())
+                .andExpect(jsonPath("$.result.number").doesNotExist())
+                .andExpect(jsonPath("$.result.numberOfElements").doesNotExist())
+                .andExpect(jsonPath("$.result.first").doesNotExist())
+                .andExpect(jsonPath("$.result.last").doesNotExist());
     }
 
     @Test


### PR DESCRIPTION
## 요약
- Close #154
- 게시글 목록 API에서 Spring Data `Slice` 직렬화 구조가 외부 응답 계약으로 노출되지 않도록 전용 응답 DTO로 분리했습니다.
- 목록 응답 계약을 `result.items`, `result.page`, `result.size`, `result.hasNext`로 정리했습니다.
- 새 게시글 목록 응답 계약 문서를 추가했습니다.

## 변경 사항
- 게시글 목록 조회 서비스/컨트롤러 반환 타입에서 `Slice<...>`를 제거했습니다.
- Repository 계층의 `Slice<Post>` 사용은 persistence 내부 구현으로 유지했습니다.
- MockMvc 테스트에서 새 JSON shape를 검증하고, 기존 Slice 필드가 응답에 없는지 확인하도록 수정했습니다.
- 쿼리 수 통합 테스트를 새 목록 DTO의 `items` 기준으로 갱신했습니다.

## 검증
- `sh gradlew test`
- `git diff --check`
