### PR TITLE
refactor: service response DTO 반환 구조 분리

### DIFF
--- a/src/main/java/com/mogak/spring/service/AuthService.java
+++ b/src/main/java/com/mogak/spring/service/AuthService.java
@@ -19,11 +19,10 @@ import com.mogak.spring.jwt.JwtTokenProvider;
 import com.mogak.spring.jwt.JwtTokens;
 import com.mogak.spring.repository.*;
 import com.mogak.spring.security.SecurityAuthority;
+import com.mogak.spring.service.result.auth.SocialLoginResult;
+import com.mogak.spring.service.result.auth.WithdrawResult;
 import com.mogak.spring.web.dto.authdto.AppleLoginRequest;
-import com.mogak.spring.web.dto.authdto.AppleLoginResponse;
-import com.mogak.spring.web.dto.authdto.AuthResponse;
 import com.mogak.spring.web.dto.authdto.SocialLoginRequest;
-import com.mogak.spring.web.dto.authdto.SocialLoginResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -57,21 +56,20 @@ public class AuthService {
 
     //로그인
     @Transactional
-    public AppleLoginResponse appleLogin(AppleLoginRequest request) {
-        SocialLoginResponse response = login(SocialProvider.APPLE, request.idToken());
-        return new AppleLoginResponse(response.isRegistered(), response.userId(), response.tokens());
+    public SocialLoginResult appleLogin(AppleLoginRequest request) {
+        return login(SocialProvider.APPLE, request.idToken());
     }
 
     @Transactional
-    public SocialLoginResponse socialLogin(SocialProvider provider, SocialLoginRequest request) {
+    public SocialLoginResult socialLogin(SocialProvider provider, SocialLoginRequest request) {
         return login(provider, request.token());
     }
 
-    private SocialLoginResponse login(SocialProvider provider, String token) {
+    private SocialLoginResult login(SocialProvider provider, String token) {
         SocialUserProfile profile = resolveSocialUser(provider, token);
         User user = resolveUser(profile);
         JwtTokens jwtTokens = issueTokens(user);
-        return new SocialLoginResponse(isRegisterNickname(user), user.getId(), jwtTokens);
+        return new SocialLoginResult(isRegisterNickname(user), user.getId(), jwtTokens);
     }
 
     private SocialUserProfile resolveSocialUser(SocialProvider provider, String token) {
@@ -205,11 +203,11 @@ public class AuthService {
      * 로그인한 사용자 탈퇴
      */
     @Transactional
-    public AuthResponse.WithdrawDto deleteUser(Long userId) {
+    public WithdrawResult deleteUser(Long userId) {
         User deleteUser = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         deleteUserInfo(deleteUser);
-        return new AuthResponse.WithdrawDto(true);
+        return new WithdrawResult(true);
     }
 
     public void deleteUserInfo(User deleteUser) {

--- a/src/main/java/com/mogak/spring/service/FollowService.java
+++ b/src/main/java/com/mogak/spring/service/FollowService.java
@@ -1,9 +1,9 @@
 package com.mogak.spring.service;
 
-import java.util.List;
+import com.mogak.spring.service.result.follow.FollowCountResult;
+import com.mogak.spring.service.result.follow.FollowUserResult;
 
-import static com.mogak.spring.web.dto.userdto.FollowRequestDto.CountDto;
-import static com.mogak.spring.web.dto.userdto.UserResponseDto.UserDto;
+import java.util.List;
 
 public interface FollowService {
 
@@ -11,9 +11,9 @@ public interface FollowService {
 
     void unfollow(Long userId, String nickname);
 
-    CountDto getFollowCount(String nickname);
+    FollowCountResult getFollowCount(String nickname);
 
-    List<UserDto> getMotoList(String nickname);
+    List<FollowUserResult> getMotoList(String nickname);
 
-    List<UserDto> getMentorList(String nickname);
+    List<FollowUserResult> getMentorList(String nickname);
 }

--- a/src/main/java/com/mogak/spring/service/FollowServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/FollowServiceImpl.java
@@ -6,15 +6,14 @@ import com.mogak.spring.exception.UserException;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.repository.FollowRepository;
 import com.mogak.spring.repository.UserRepository;
-import com.mogak.spring.web.dto.userdto.FollowRequestDto;
+import com.mogak.spring.service.result.follow.FollowCountResult;
+import com.mogak.spring.service.result.follow.FollowUserResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static com.mogak.spring.web.dto.userdto.UserResponseDto.UserDto;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -47,27 +46,31 @@ public class FollowServiceImpl implements FollowService {
     }
 
     @Override
-    public FollowRequestDto.CountDto getFollowCount(String nickname) {
+    public FollowCountResult getFollowCount(String nickname) {
         User user = userRepository.findActiveByNickname(nickname).orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
-        return new FollowRequestDto.CountDto(getMentorCount(user), getMotoCount(user));
+        return new FollowCountResult(getMentorCount(user), getMotoCount(user));
     }
 
     @Override
-    public List<UserDto> getMotoList(String nickname) {
+    public List<FollowUserResult> getMotoList(String nickname) {
         User user = userRepository.findActiveByNickname(nickname).orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         List<User> users = followRepository.findMotosByUser(user);
         return users.stream()
-                .map(UserDto::from)
+                .map(this::toFollowUserResult)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<UserDto> getMentorList(String nickname) {
+    public List<FollowUserResult> getMentorList(String nickname) {
         User user = userRepository.findActiveByNickname(nickname).orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         List<User> users = followRepository.findMentorsByUser(user);
         return users.stream()
-                .map(UserDto::from)
+                .map(this::toFollowUserResult)
                 .collect(Collectors.toList());
+    }
+
+    private FollowUserResult toFollowUserResult(User user) {
+        return new FollowUserResult(user.getNickname(), user.getJob().getName());
     }
 
     private int getMotoCount(User user) {

--- a/src/main/java/com/mogak/spring/service/JogakService.java
+++ b/src/main/java/com/mogak/spring/service/JogakService.java
@@ -1,7 +1,12 @@
 package com.mogak.spring.service;
 
+import com.mogak.spring.service.result.jogak.CreateJogakResult;
+import com.mogak.spring.service.result.jogak.DailyJogakListResult;
+import com.mogak.spring.service.result.jogak.DetailJogakResult;
+import com.mogak.spring.service.result.jogak.JogakDailyJogakResult;
+import com.mogak.spring.service.result.jogak.OneTimeJogakListResult;
+import com.mogak.spring.service.result.jogak.RoutineJogakResult;
 import com.mogak.spring.web.dto.jogakdto.JogakRequestDto;
-import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -9,23 +14,23 @@ import java.util.List;
 public interface JogakService {
 
     void createRoutineJogakToday();
-    JogakResponseDto.CreateJogakDto createJogak(Long userId, JogakRequestDto.CreateJogakDto createJogakDto);
-    JogakResponseDto.CreateJogakDto updateJogak(Long userId, Long jogakId, JogakRequestDto.UpdateJogakDto updateJogakDto);
-    JogakResponseDto.GetOneTimeJogakListDto getDailyJogaks(Long userId, LocalDate day);
-    JogakResponseDto.GetDailyJogakListDto getDayJogaks(Long userId, LocalDate day);
+    CreateJogakResult createJogak(Long userId, JogakRequestDto.CreateJogakDto createJogakDto);
+    CreateJogakResult updateJogak(Long userId, Long jogakId, JogakRequestDto.UpdateJogakDto updateJogakDto);
+    OneTimeJogakListResult getDailyJogaks(Long userId, LocalDate day);
+    DailyJogakListResult getDayJogaks(Long userId, LocalDate day);
 //    void failRoutineJogakAtMidnight();
 //    void failJogakAtFour();
 
-    JogakResponseDto.JogakDailyJogakDto startJogak(Long userId, Long jogakId);
+    JogakDailyJogakResult startJogak(Long userId, Long jogakId);
 
-    JogakResponseDto.JogakDailyJogakDto successJogak(Long userId, Long dailyJogakId);
+    JogakDailyJogakResult successJogak(Long userId, Long dailyJogakId);
 
     void deleteJogak(Long userId, Long jogakId);
     void deleteJogakCascadeAfterParentAuthorization(Long jogakId);
 
-    List<JogakResponseDto.GetRoutineJogakDto> getRoutineJogaks(Long userId, LocalDate startDay, LocalDate endDay);
+    List<RoutineJogakResult> getRoutineJogaks(Long userId, LocalDate startDay, LocalDate endDay);
 
-    JogakResponseDto.JogakDailyJogakDto failJogak(Long userId, Long dailyJogakId);
+    JogakDailyJogakResult failJogak(Long userId, Long dailyJogakId);
 
-    JogakResponseDto.DetailJogakDto getJogakDetail(Long userId, Long jogakId);
+    DetailJogakResult getJogakDetail(Long userId, Long jogakId);
 }

--- a/src/main/java/com/mogak/spring/service/JogakServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/JogakServiceImpl.java
@@ -16,8 +16,14 @@ import com.mogak.spring.exception.MogakException;
 import com.mogak.spring.exception.UserException;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.repository.*;
+import com.mogak.spring.service.result.jogak.CreateJogakResult;
+import com.mogak.spring.service.result.jogak.DailyJogakListResult;
+import com.mogak.spring.service.result.jogak.DailyJogakResult;
+import com.mogak.spring.service.result.jogak.DetailJogakResult;
+import com.mogak.spring.service.result.jogak.JogakDailyJogakResult;
+import com.mogak.spring.service.result.jogak.OneTimeJogakListResult;
+import com.mogak.spring.service.result.jogak.RoutineJogakResult;
 import com.mogak.spring.web.dto.jogakdto.JogakRequestDto;
-import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -89,7 +95,7 @@ public class JogakServiceImpl implements JogakService {
 
     @Transactional
     @Override
-    public JogakResponseDto.CreateJogakDto createJogak(Long userId, JogakRequestDto.CreateJogakDto createJogakDto) {
+    public CreateJogakResult createJogak(Long userId, JogakRequestDto.CreateJogakDto createJogakDto) {
         Mogak mogak = mogakRepository.findActiveById(createJogakDto.mogakId())
                 .orElseThrow(() -> new MogakException(ErrorCode.NOT_EXIST_MOGAK));
         validateMogakOwner(userId, mogak);
@@ -129,10 +135,10 @@ public class JogakServiceImpl implements JogakService {
                 jogakPeriodRepository.save(JogakPeriod.of(period, jogak));
                 days.add(period.getDays());
             }
-            return JogakResponseDto.createFromJogak(jogak, days);
+            return CreateJogakResult.of(jogak, days);
         }
         // 루틴이 없는 경우
-        return JogakResponseDto.createFromJogak(jogak);
+        return CreateJogakResult.of(jogak, null);
     }
 
     // 모각의 조각 개수 검증
@@ -142,7 +148,7 @@ public class JogakServiceImpl implements JogakService {
 
     @Transactional
     @Override
-    public JogakResponseDto.CreateJogakDto updateJogak(Long userId, Long jogakId, JogakRequestDto.UpdateJogakDto updateJogakDto) {
+    public CreateJogakResult updateJogak(Long userId, Long jogakId, JogakRequestDto.UpdateJogakDto updateJogakDto) {
         Jogak jogak = jogakRepository.findActiveById(jogakId)
                 .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
         validateJogakOwner(userId, jogak);
@@ -157,7 +163,7 @@ public class JogakServiceImpl implements JogakService {
             jogakPeriodRepository.deleteAllByJogakId(jogak.getId());
         }
 
-        return JogakResponseDto.createFromJogak(jogak);
+        return CreateJogakResult.of(jogak, null);
     }
 
     private void validatePeriod(Optional<Boolean> isRoutineOptional, Optional<List<String>> daysOptional) {
@@ -214,47 +220,51 @@ public class JogakServiceImpl implements JogakService {
     }
 
     @Override
-    public JogakResponseDto.GetOneTimeJogakListDto getDailyJogaks(Long userId, LocalDate day) {
+    public OneTimeJogakListResult getDailyJogaks(Long userId, LocalDate day) {
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         List<Jogak> jogakList = jogakRepository.findActiveOneTimeJogaksByUser(user);
         List<DailyJogak> dailyJogak = dailyJogakRepository.findDailyJogaks(user, day);
-        return JogakResponseDto.oneTimeJogakListFrom(jogakList, dailyJogak);
+        return OneTimeJogakListResult.of(jogakList, dailyJogak);
     }
 
     @Override
-    public JogakResponseDto.GetDailyJogakListDto getDayJogaks(Long userId, LocalDate day) {
+    public DailyJogakListResult getDayJogaks(Long userId, LocalDate day) {
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         if (day.isAfter(LocalDate.now())) {
             // 미래 루틴 조각 가져오기
             List<Jogak> userRoutineJogaks = jogakRepository.findDailyRoutineJogaks(user, dateToNum(day));
-            return JogakResponseDto.dailyJogakListFromDtos(
+            return DailyJogakListResult.from(
                     userRoutineJogaks.stream()
                             .filter(jogak -> jogak.getEndAt() == null || jogak.getEndAt().isAfter(day))
-                            .map(JogakResponseDto::futureDailyJogakFromJogak)
-                            .collect(Collectors.toList()));
+                            .map(DailyJogakResult::futureFrom)
+                            .toList());
         }
-        return JogakResponseDto.dailyJogakListFrom(dailyJogakRepository.findDailyJogaks(user, day));
+        return DailyJogakListResult.from(
+                dailyJogakRepository.findDailyJogaks(user, day).stream()
+                        .map(DailyJogakResult::from)
+                        .toList()
+        );
     }
 
     /**
      * 주간/월간 루틴 가져오는 API
      * */
     @Override
-    public List<JogakResponseDto.GetRoutineJogakDto> getRoutineJogaks(Long userId, LocalDate startDate, LocalDate endDate) {
+    public List<RoutineJogakResult> getRoutineJogaks(Long userId, LocalDate startDate, LocalDate endDate) {
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         List<LocalDate> pastDates = getPastDates(startDate, endDate);
         List<LocalDate> futureDates = getFutureDates(startDate, endDate);
-        List<JogakResponseDto.GetRoutineJogakDto> routineJogaks = new ArrayList<>();
+        List<RoutineJogakResult> routineJogaks = new ArrayList<>();
 
         // 오늘 + 이전 가져오기
         if (!pastDates.isEmpty()) {
             List<DailyJogak> pastJogaks = dailyJogakRepository.findDailyJogaksBetween(user, startDate, endDate);
             routineJogaks.addAll(pastJogaks.stream()
-                    .map(JogakResponseDto::routineJogakFrom)
-                    .collect(Collectors.toList()));
+                    .map(RoutineJogakResult::from)
+                    .toList());
         }
 
         // 미래 가져오기
@@ -280,7 +290,7 @@ public class JogakServiceImpl implements JogakService {
                             log.debug(i.getEndAt() + " , " + date);
                             // 기간에 해당하지 않는 조각은 가져오지 않는 로직
                             if (i.getEndAt() == null || i.getEndAt().isAfter(date)) {
-                                routineJogaks.add(JogakResponseDto.futureRoutineJogakFrom(date, i.getTitle()));
+                                routineJogaks.add(RoutineJogakResult.futureFrom(date, i.getTitle()));
                             }
                         });
             }
@@ -312,7 +322,7 @@ public class JogakServiceImpl implements JogakService {
 
     @Transactional
     @Override
-    public JogakResponseDto.JogakDailyJogakDto startJogak(Long userId, Long jogakId) {
+    public JogakDailyJogakResult startJogak(Long userId, Long jogakId) {
         Jogak jogak = jogakRepository.findActiveById(jogakId)
                 .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
         validateJogakOwner(userId, jogak);
@@ -323,12 +333,12 @@ public class JogakServiceImpl implements JogakService {
             throw new JogakException(ErrorCode.ALREADY_START_JOGAK);
         }
         DailyJogak dailyJogak = dailyJogakRepository.save(DailyJogak.create(jogak, today));
-        return JogakResponseDto.jogakDailyJogakFrom(jogak, dailyJogak);
+        return JogakDailyJogakResult.of(jogak, dailyJogak);
     }
 
     @Transactional
     @Override
-    public JogakResponseDto.JogakDailyJogakDto successJogak(Long userId, Long dailyJogakId) {
+    public JogakDailyJogakResult successJogak(Long userId, Long dailyJogakId) {
         DailyJogak dailyJogak = dailyJogakRepository.findActiveByIdWithJogakGraph(dailyJogakId)
                 .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_DAILY_JOGAK));
         validateDailyJogakOwner(userId, dailyJogak);
@@ -336,12 +346,12 @@ public class JogakServiceImpl implements JogakService {
 
         updateStatus(DailyJogakStatus.SUCCESS, jogak, dailyJogak);
 
-        return JogakResponseDto.jogakDailyJogakFrom(jogak, dailyJogak);
+        return JogakDailyJogakResult.of(jogak, dailyJogak);
     }
 
     @Transactional
     @Override
-    public JogakResponseDto.JogakDailyJogakDto failJogak(Long userId, Long dailyJogakId) {
+    public JogakDailyJogakResult failJogak(Long userId, Long dailyJogakId) {
         DailyJogak dailyJogak = dailyJogakRepository.findActiveByIdWithJogakGraph(dailyJogakId)
                 .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_DAILY_JOGAK));
         validateDailyJogakOwner(userId, dailyJogak);
@@ -349,7 +359,7 @@ public class JogakServiceImpl implements JogakService {
 
         updateStatus(DailyJogakStatus.FAIL, jogak, dailyJogak);
 
-        return JogakResponseDto.jogakDailyJogakFrom(jogak, dailyJogak);
+        return JogakDailyJogakResult.of(jogak, dailyJogak);
     }
 
     private void updateStatus(DailyJogakStatus nextStatus, Jogak jogak, DailyJogak dailyJogak) {
@@ -372,7 +382,7 @@ public class JogakServiceImpl implements JogakService {
         dailyJogak.updateStatus(nextStatus);
     }
 
-    private JogakResponseDto.DetailJogakDto getJogakDetail(Jogak jogak) {
+    private DetailJogakResult getJogakDetail(Jogak jogak) {
         Mogak mogak = mogakRepository.findByJogak(jogak)
                 .orElseThrow(() -> new BaseException(ErrorCode.NOT_EXIST_MOGAK));
 
@@ -380,13 +390,13 @@ public class JogakServiceImpl implements JogakService {
             List<String> periods = periodRepository.findPeriodsByJogak(jogak).stream()
                     .map(Period::getDays)
                     .collect(Collectors.toList());
-            return JogakResponseDto.detailFromJogak(jogak, mogak.getColor(), periods);
+            return DetailJogakResult.of(jogak, mogak.getColor(), periods);
         }
-        return JogakResponseDto.detailFromJogak(jogak, mogak.getColor());
+        return DetailJogakResult.of(jogak, mogak.getColor(), null);
     }
 
     @Override
-    public JogakResponseDto.DetailJogakDto getJogakDetail(Long userId, Long jogakId) {
+    public DetailJogakResult getJogakDetail(Long userId, Long jogakId) {
         Jogak jogak = jogakRepository.findActiveById(jogakId)
                 .orElseThrow(() -> new JogakException(ErrorCode.NOT_EXIST_JOGAK));
         validateJogakOwner(userId, jogak);

--- a/src/main/java/com/mogak/spring/service/ModaratService.java
+++ b/src/main/java/com/mogak/spring/service/ModaratService.java
@@ -1,17 +1,16 @@
 package com.mogak.spring.service;
 
 import com.mogak.spring.domain.modarat.Modarat;
-import com.mogak.spring.repository.query.SingleDetailModaratDto;
+import com.mogak.spring.service.result.modarat.ModaratDetailResult;
+import com.mogak.spring.service.result.modarat.ModaratResult;
 import com.mogak.spring.web.dto.modaratdto.ModaratRequestDto;
 
 import java.util.List;
-
-import static com.mogak.spring.web.dto.modaratdto.ModaratResponseDto.ModaratDto;
 
 public interface ModaratService {
     Modarat create(Long userId, ModaratRequestDto.CreateModaratDto request);
     void delete(Long userId, Long modaratId);
     Modarat update(Long userId, Long modaratId, ModaratRequestDto.UpdateModaratDto request);
-    SingleDetailModaratDto getDetailModarat(Long userId, Long modaratId);
-    List<ModaratDto> getModaratList(Long userId);
+    ModaratDetailResult getDetailModarat(Long userId, Long modaratId);
+    List<ModaratResult> getModaratList(Long userId);
 }

--- a/src/main/java/com/mogak/spring/service/ModaratServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/ModaratServiceImpl.java
@@ -12,8 +12,9 @@ import com.mogak.spring.repository.MogakRepository;
 import com.mogak.spring.repository.UserRepository;
 import com.mogak.spring.repository.query.GetMogakInModaratDto;
 import com.mogak.spring.repository.query.SingleDetailModaratDto;
+import com.mogak.spring.service.result.modarat.ModaratDetailResult;
+import com.mogak.spring.service.result.modarat.ModaratResult;
 import com.mogak.spring.web.dto.modaratdto.ModaratRequestDto;
-import com.mogak.spring.web.dto.modaratdto.ModaratResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,18 +57,27 @@ public class ModaratServiceImpl implements ModaratService {
     }
 
     @Override
-    public SingleDetailModaratDto getDetailModarat(Long userId, Long modaratId) {
+    public ModaratDetailResult getDetailModarat(Long userId, Long modaratId) {
         Modarat modarat = getOwnedModarat(modaratId, userId);
         List<GetMogakInModaratDto> mogakDtoList = modaratRepository.findMogakDtoListByModaratId(modarat.getId()).orElse(List.of());
         SingleDetailModaratDto modaratDto = modaratRepository.findOneDetailModarat(modaratId);
-        return modaratDto.withMogakDtoList(mogakDtoList);
+        SingleDetailModaratDto detail = modaratDto.withMogakDtoList(mogakDtoList);
+        List<ModaratDetailResult.MogakInModaratResult> mogaks = detail.mogakDtoList().stream()
+                .map(mogak -> new ModaratDetailResult.MogakInModaratResult(
+                        mogak.title(),
+                        mogak.bigCategory(),
+                        mogak.smallCategory(),
+                        mogak.color()
+                ))
+                .toList();
+        return new ModaratDetailResult(detail.id(), detail.title(), detail.color(), mogaks);
     }
 
     @Override
-    public List<ModaratResponseDto.ModaratDto> getModaratList(Long userId) {
+    public List<ModaratResult> getModaratList(Long userId) {
         userRepository.findActiveById(userId).orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         return modaratRepository.findModaratsByUserId(userId).stream()
-                .map(ModaratResponseDto.ModaratDto::from)
+                .map(modarat -> new ModaratResult(modarat.getId(), modarat.getTitle(), modarat.getColor()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/mogak/spring/service/MogakService.java
+++ b/src/main/java/com/mogak/spring/service/MogakService.java
@@ -1,21 +1,21 @@
 package com.mogak.spring.service;
 
-import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
+import com.mogak.spring.service.result.mogak.GetJogakResult;
+import com.mogak.spring.service.result.mogak.GetMogakListResult;
+import com.mogak.spring.service.result.mogak.GetMogakResult;
 import com.mogak.spring.web.dto.mogakdto.MogakRequestDto;
-import com.mogak.spring.web.dto.mogakdto.MogakResponseDto;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface MogakService {
-    MogakResponseDto.GetMogakDto create(Long userId, MogakRequestDto.CreateDto createDto);
-//    MogakResponseDto.UpdateStateDto achieveMogak(Long id);
-    MogakResponseDto.GetMogakDto updateMogak(Long userId, MogakRequestDto.UpdateDto request);
-    MogakResponseDto.GetMogakListDto getMogakDtoList(Long userId, Long modaratId);
+    GetMogakResult create(Long userId, MogakRequestDto.CreateDto createDto);
+    GetMogakResult updateMogak(Long userId, MogakRequestDto.UpdateDto request);
+    GetMogakListResult getMogakDtoList(Long userId, Long modaratId);
     void deleteMogak(Long userId, Long mogakId);
     void deleteMogakCascadeAfterParentAuthorization(Long mogakId);
 
-    List<JogakResponseDto.GetJogakDto> getJogaks(Long userId, Long mogakId, LocalDate day);
+    List<GetJogakResult> getJogaks(Long userId, Long mogakId, LocalDate day);
 //    List<Mogak> getOngoingTodayMogakList(int name);
 //    void judgeMogakByDay(LocalDate day);
 }

--- a/src/main/java/com/mogak/spring/service/MogakServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/MogakServiceImpl.java
@@ -12,9 +12,10 @@ import com.mogak.spring.exception.MogakException;
 import com.mogak.spring.exception.UserException;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.repository.*;
-import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
+import com.mogak.spring.service.result.mogak.GetJogakResult;
+import com.mogak.spring.service.result.mogak.GetMogakListResult;
+import com.mogak.spring.service.result.mogak.GetMogakResult;
 import com.mogak.spring.web.dto.mogakdto.MogakRequestDto;
-import com.mogak.spring.web.dto.mogakdto.MogakResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,7 +45,7 @@ public class MogakServiceImpl implements MogakService {
      * */
     @Transactional
     @Override
-    public MogakResponseDto.GetMogakDto create(Long userId, MogakRequestDto.CreateDto request) {
+    public GetMogakResult create(Long userId, MogakRequestDto.CreateDto request) {
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         Modarat modarat = getOwnedModarat(request.modaratId(), userId);
@@ -118,7 +119,7 @@ public class MogakServiceImpl implements MogakService {
      * */
     @Transactional
     @Override
-    public MogakResponseDto.GetMogakDto updateMogak(Long userId, MogakRequestDto.UpdateDto request) {
+    public GetMogakResult updateMogak(Long userId, MogakRequestDto.UpdateDto request) {
         Mogak mogak = getOwnedMogak(request.mogakId(), userId);
         Optional<String> categoryOptional = Optional.ofNullable(request.bigCategory());
         categoryOptional.ifPresent(categoryValue -> {
@@ -137,14 +138,14 @@ public class MogakServiceImpl implements MogakService {
      * 모각 리스트 조회
      * */
     @Override
-    public MogakResponseDto.GetMogakListDto getMogakDtoList(Long userId, Long modaratId) {
+    public GetMogakListResult getMogakDtoList(Long userId, Long modaratId) {
         userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         Modarat modarat = getOwnedModarat(modaratId, userId);
-        List<MogakResponseDto.GetMogakDto> mogaks = mogakRepository.findAllByModaratId(modarat.getId()).stream()
+        List<GetMogakResult> mogaks = mogakRepository.findAllByModaratId(modarat.getId()).stream()
                 .map(this::toGetMogakDto)
                 .collect(Collectors.toList());
-        return new MogakResponseDto.GetMogakListDto(mogaks, mogaks.size());
+        return new GetMogakListResult(mogaks, mogaks.size());
     }
 
     /**
@@ -224,14 +225,25 @@ public class MogakServiceImpl implements MogakService {
     }
 
     @Override
-    public List<JogakResponseDto.GetJogakDto> getJogaks(Long userId, Long mogakId, LocalDate day) {
+    public List<GetJogakResult> getJogaks(Long userId, Long mogakId, LocalDate day) {
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         Mogak mogak = getOwnedMogak(mogakId, userId);
         List<DailyJogak> dailyJogak = dailyJogakRepository.findDailyJogaks(user, day);
         return jogakRepository.findAllByMogakWithFetchGraph(mogak).stream()
                 .filter(jogak -> jogak.getEndAt() == null || jogak.getEndAt().isAfter(day.minusDays(1)))
-                .map(jogak -> JogakResponseDto.getJogakFrom(jogak, findCorrespondingDailyJogak(jogak, dailyJogak)))
+                .map(jogak -> new GetJogakResult(
+                        jogak.getId(),
+                        jogak.getMogak().getTitle(),
+                        jogak.getCategory().getName(),
+                        jogak.getTitle(),
+                        jogak.getIsRoutine(),
+                        jogak.getPeriods(),
+                        findCorrespondingDailyJogak(jogak, dailyJogak),
+                        jogak.getAchievements(),
+                        jogak.getStartAt(),
+                        jogak.getEndAt()
+                ))
                 .collect(Collectors.toList());
     }
 
@@ -240,8 +252,8 @@ public class MogakServiceImpl implements MogakService {
                 .anyMatch(dailyJogak -> dailyJogak.getJogak().equals(jogak));
     }
 
-    private MogakResponseDto.GetMogakDto toGetMogakDto(Mogak mogak) {
-        return new MogakResponseDto.GetMogakDto(
+    private GetMogakResult toGetMogakDto(Mogak mogak) {
+        return new GetMogakResult(
                 mogak.getId(),
                 mogak.getTitle(),
                 mogak.getBigCategory(),

--- a/src/main/java/com/mogak/spring/service/PostService.java
+++ b/src/main/java/com/mogak/spring/service/PostService.java
@@ -2,29 +2,28 @@ package com.mogak.spring.service;
 
 import com.mogak.spring.domain.post.Post;
 import com.mogak.spring.domain.post.PostImg;
+import com.mogak.spring.service.result.post.NetworkFeedPostResult;
+import com.mogak.spring.service.result.post.PacemakerPostResult;
+import com.mogak.spring.service.result.post.PostSummaryResult;
 import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
 import com.mogak.spring.web.dto.postdto.PostRequestDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto.GetAllNetworkDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto.GetPostDto;
 import org.springframework.data.domain.Slice;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.time.LocalDate;
 
-import static com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkPostDto;
-
 public interface PostService {
 
     void validateCreateAccess(Long userId, PostRequestDto.CreatePostDto request, List<MultipartFile> multipartFile, Long jogakId);
     Post create(Long userId, PostRequestDto.CreatePostDto request, List<PostImgRequestDto.CreatePostImgDto> postImgDtoList, Long jogakId);
     Post getByJogakAndTargetDate(Long userId, Long jogakId, LocalDate targetDate);
-    Slice<GetPostDto> getAllPosts(Long userId, int page, Long mogakId, int size);
+    Slice<PostSummaryResult> getAllPosts(Long userId, int page, Long mogakId, int size);
     Post findById(Long userId, Long postId);
     Post update(Long userId, Long postId, PostRequestDto.UpdatePostDto request);
     void delete(Long userId, Long postId);
-    List<NetworkPostDto> getPacemakerPosts(Long userId, int cursor, int size);
-    Slice<GetAllNetworkDto> getNetworkPosts(Long userId, int page, int size, String sort, String address);
+    List<PacemakerPostResult> getPacemakerPosts(Long userId, int cursor, int size);
+    Slice<NetworkFeedPostResult> getNetworkPosts(Long userId, int page, int size, String sort, String address);
     List<String> findImgUrlByPost(Long postId);
     List<Long> findActiveCommentIds(Post post);
     List<String> findNotThumbnailImg(Post post);

--- a/src/main/java/com/mogak/spring/service/PostServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/PostServiceImpl.java
@@ -14,13 +14,13 @@ import com.mogak.spring.exception.PostException;
 import com.mogak.spring.exception.UserException;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.repository.*;
+import com.mogak.spring.service.result.post.NetworkCommentResult;
+import com.mogak.spring.service.result.post.NetworkFeedPostResult;
+import com.mogak.spring.service.result.post.NetworkUserResult;
+import com.mogak.spring.service.result.post.PacemakerPostResult;
+import com.mogak.spring.service.result.post.PostSummaryResult;
 import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
 import com.mogak.spring.web.dto.postdto.PostRequestDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto.GetAllNetworkDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto.GetPostDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkPostDto;
-import com.mogak.spring.web.dto.commentdto.CommentResponseDto;
-import com.mogak.spring.web.dto.userdto.UserResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
@@ -116,12 +116,26 @@ public class PostServiceImpl implements PostService {
 
     //회고록 조회 - 무한 스크롤
     @Override
-    public Slice<GetPostDto> getAllPosts(Long userId, int page, Long mogakId, int size) {
+    public Slice<PostSummaryResult> getAllPosts(Long userId, int page, Long mogakId, int size) {
         getOwnedMogak(userId, mogakId);
         Pageable pageable = PageRequest.of(page, size);
 
         return postRepository.findAllPosts(mogakId, pageable)
-                .map(GetPostDto::from);
+                .map(this::toPostSummaryResult);
+    }
+
+    private PostSummaryResult toPostSummaryResult(Post post) {
+        DailyJogak dailyJogak = post.getDailyJogak();
+        return new PostSummaryResult(
+                post.getId(),
+                dailyJogak.getJogak().getMogak().getId(),
+                dailyJogak.getJogak().getId(),
+                dailyJogak.getId(),
+                dailyJogak.getTargetDate(),
+                post.getContents(),
+                post.getPostThumbnailUrl(),
+                post.getLikeCnt()
+        );
     }
 
     //회고록 상세 조회 + 댓글, 이미지 같이 보이게
@@ -167,7 +181,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public List<NetworkPostDto> getPacemakerPosts(Long userId, int cursor, int size) {
+    public List<PacemakerPostResult> getPacemakerPosts(Long userId, int cursor, int size) {
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         Pageable pageable = PageRequest.of(cursor, size);
@@ -179,15 +193,22 @@ public class PostServiceImpl implements PostService {
         return posts.stream()
                 .map(p -> {
                     List<String> imgUrls = findNotThumbnailImgUrls(p, imagesByPostId);
-                    List<CommentResponseDto.NetworkCommentDto> comments = commentsByPostId
+                    List<NetworkCommentResult> comments = commentsByPostId
                             .getOrDefault(p.getId(), Collections.emptyList()).stream()
-                            .map(CommentResponseDto.NetworkCommentDto::from)
+                            .map(comment -> NetworkCommentResult.of(
+                                    comment.getId(),
+                                    comment.getUser().getNickname(),
+                                    comment.getContents(),
+                                    comment.getCreatedAt()
+                            ))
                             .collect(Collectors.toList());
-                    return NetworkPostDto.from(
-                            p,
-                            UserResponseDto.UserDto.from(p.getUser()),
+                    return PacemakerPostResult.of(
+                            NetworkUserResult.of(p.getUser().getNickname(), p.getUser().getJob().getName()),
+                            p.getContents(),
                             imgUrls,
-                            comments
+                            comments,
+                            p.getLikeCnt(),
+                            p.getViewCnt()
                     );
                 })
                 .collect(Collectors.toList());
@@ -195,7 +216,7 @@ public class PostServiceImpl implements PostService {
 
     //전체 네트워킹 조회 - 이미지 썸네일 제외 반환
     @Override
-    public Slice<GetAllNetworkDto> getNetworkPosts(Long userId, int page, int size, String sort, String address /*List<String> categoryList,*/){
+    public Slice<NetworkFeedPostResult> getNetworkPosts(Long userId, int page, int size, String sort, String address /*List<String> categoryList,*/){
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         if(address == null){
@@ -204,7 +225,15 @@ public class PostServiceImpl implements PostService {
         Pageable pageable = PageRequest.of(page, size);
         Slice<Post> posts = postRepository.findNetworkPosts(address, sort, pageable);
         Map<Long, List<PostImg>> imagesByPostId = groupImagesByPostId(extractPostIds(posts.getContent()));
-        return posts.map(post -> GetAllNetworkDto.from(post, findNotThumbnailImgUrls(post, imagesByPostId)));
+        return posts.map(post -> NetworkFeedPostResult.of(
+                post.getId(),
+                post.getUser().getNickname(),
+                post.getUser().getJob().getName(),
+                post.getContents(),
+                findNotThumbnailImgUrls(post, imagesByPostId),
+                post.getCommentCnt(),
+                post.getLikeCnt()
+        ));
     }
 
     private List<Long> extractPostIds(List<Post> posts) {

--- a/src/main/java/com/mogak/spring/service/UserService.java
+++ b/src/main/java/com/mogak/spring/service/UserService.java
@@ -1,12 +1,13 @@
 package com.mogak.spring.service;
 
 import com.mogak.spring.domain.user.User;
+import com.mogak.spring.service.result.user.UserCreateResult;
+import com.mogak.spring.service.result.user.UserProfileResult;
 import com.mogak.spring.web.dto.userdto.UserRequestDto;
-import com.mogak.spring.web.dto.userdto.UserResponseDto;
 
 public interface UserService {
 
-    UserResponseDto.CreateDto create(Long userId, UserRequestDto.CreateUserDto request, UserRequestDto.UploadImageDto uploadImageDto);
+    UserCreateResult create(Long userId, UserRequestDto.CreateUserDto request, UserRequestDto.UploadImageDto uploadImageDto);
     Boolean verifyNickname(String request);
   
     String getToken(User user);
@@ -20,6 +21,6 @@ public interface UserService {
   
     void updateImg(Long userId, UserRequestDto.UpdateImageDto userImageDto);
 
-    UserResponseDto.GetUserDto getUserProfile(Long userId);
+    UserProfileResult getUserProfile(Long userId);
 
 }

--- a/src/main/java/com/mogak/spring/service/UserServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/UserServiceImpl.java
@@ -12,9 +12,10 @@ import com.mogak.spring.repository.AddressRepository;
 import com.mogak.spring.repository.JobRepository;
 import com.mogak.spring.repository.UserRepository;
 import com.mogak.spring.security.SecurityAuthority;
+import com.mogak.spring.service.result.user.UserCreateResult;
+import com.mogak.spring.service.result.user.UserProfileResult;
 import com.mogak.spring.util.Regex;
 import com.mogak.spring.web.dto.userdto.UserRequestDto;
-import com.mogak.spring.web.dto.userdto.UserResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,7 +35,7 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     @Override
-    public UserResponseDto.CreateDto create(Long userId, CreateUserDto request, UploadImageDto uploadImageDto) {
+    public UserCreateResult create(Long userId, CreateUserDto request, UploadImageDto uploadImageDto) {
         inputVerify(request);
         Job job = jobRepository.findJobByName(request.job())
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_JOB));
@@ -49,7 +50,7 @@ public class UserServiceImpl implements UserService {
         }
         user.registerUser(request.nickname(), job, address, profileImgUrl, profileImgName);
         JwtTokens tokens = issueUserTokens(user);
-        return new UserResponseDto.CreateDto(user.getId(), user.getNickname(), tokens);
+        return new UserCreateResult(user.getId(), user.getNickname(), tokens);
     }
 
     private Optional<User> findUserByNickname(String nickname) {
@@ -149,12 +150,12 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserResponseDto.GetUserDto getUserProfile(Long userId) {
+    public UserProfileResult getUserProfile(Long userId) {
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         String nickname = user.getNickname();
         String job = user.getJob().getName();
         String profileImgUrl = user.getProfileImgUrl();
-        return new UserResponseDto.GetUserDto(nickname, job, profileImgUrl);
+        return new UserProfileResult(nickname, job, profileImgUrl);
     }
 }

--- a/src/main/java/com/mogak/spring/service/result/auth/SocialLoginResult.java
+++ b/src/main/java/com/mogak/spring/service/result/auth/SocialLoginResult.java
@@ -1,0 +1,6 @@
+package com.mogak.spring.service.result.auth;
+
+import com.mogak.spring.jwt.JwtTokens;
+
+public record SocialLoginResult(Boolean isRegistered, Long userId, JwtTokens tokens) {
+}

--- a/src/main/java/com/mogak/spring/service/result/auth/WithdrawResult.java
+++ b/src/main/java/com/mogak/spring/service/result/auth/WithdrawResult.java
@@ -1,0 +1,4 @@
+package com.mogak.spring.service.result.auth;
+
+public record WithdrawResult(boolean deleted) {
+}

--- a/src/main/java/com/mogak/spring/service/result/follow/FollowCountResult.java
+++ b/src/main/java/com/mogak/spring/service/result/follow/FollowCountResult.java
@@ -1,0 +1,4 @@
+package com.mogak.spring.service.result.follow;
+
+public record FollowCountResult(int mentorCnt, int motoCnt) {
+}

--- a/src/main/java/com/mogak/spring/service/result/follow/FollowUserResult.java
+++ b/src/main/java/com/mogak/spring/service/result/follow/FollowUserResult.java
@@ -1,0 +1,4 @@
+package com.mogak.spring.service.result.follow;
+
+public record FollowUserResult(String nickname, String job) {
+}

--- a/src/main/java/com/mogak/spring/service/result/jogak/CreateJogakResult.java
+++ b/src/main/java/com/mogak/spring/service/result/jogak/CreateJogakResult.java
@@ -1,0 +1,32 @@
+package com.mogak.spring.service.result.jogak;
+
+import com.mogak.spring.domain.jogak.Jogak;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CreateJogakResult(
+        Long jogakId,
+        String mogakTitle,
+        String category,
+        String title,
+        Boolean isRoutine,
+        List<String> days,
+        Integer achievements,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    public static CreateJogakResult of(Jogak jogak, List<String> days) {
+        return new CreateJogakResult(
+                jogak.getId(),
+                jogak.getMogak().getTitle(),
+                jogak.getCategory().getName(),
+                jogak.getTitle(),
+                jogak.getIsRoutine(),
+                days,
+                jogak.getAchievements(),
+                jogak.getStartAt(),
+                jogak.getEndAt()
+        );
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/jogak/DailyJogakListResult.java
+++ b/src/main/java/com/mogak/spring/service/result/jogak/DailyJogakListResult.java
@@ -1,0 +1,9 @@
+package com.mogak.spring.service.result.jogak;
+
+import java.util.List;
+
+public record DailyJogakListResult(int size, List<DailyJogakResult> dailyJogaks) {
+    public static DailyJogakListResult from(List<DailyJogakResult> dailyJogaks) {
+        return new DailyJogakListResult(dailyJogaks.size(), dailyJogaks);
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/jogak/DailyJogakResult.java
+++ b/src/main/java/com/mogak/spring/service/result/jogak/DailyJogakResult.java
@@ -1,0 +1,38 @@
+package com.mogak.spring.service.result.jogak;
+
+import com.mogak.spring.domain.jogak.DailyJogak;
+import com.mogak.spring.domain.jogak.Jogak;
+
+public record DailyJogakResult(
+        Long jogakId,
+        Long dailyJogakId,
+        String mogakTitle,
+        String category,
+        String title,
+        Boolean isRoutine,
+        Boolean isAchievement
+) {
+    public static DailyJogakResult from(DailyJogak dailyJogak) {
+        return new DailyJogakResult(
+                dailyJogak.getJogak().getId(),
+                dailyJogak.getId(),
+                dailyJogak.getMogak().getTitle(),
+                dailyJogak.getCategory().getName(),
+                dailyJogak.getTitle(),
+                dailyJogak.getIsRoutine(),
+                dailyJogak.isSuccess()
+        );
+    }
+
+    public static DailyJogakResult futureFrom(Jogak jogak) {
+        return new DailyJogakResult(
+                null,
+                -1L,
+                jogak.getMogak().getTitle(),
+                jogak.getCategory().getName(),
+                jogak.getTitle(),
+                jogak.getIsRoutine(),
+                false
+        );
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/jogak/DetailJogakResult.java
+++ b/src/main/java/com/mogak/spring/service/result/jogak/DetailJogakResult.java
@@ -1,0 +1,34 @@
+package com.mogak.spring.service.result.jogak;
+
+import com.mogak.spring.domain.jogak.Jogak;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record DetailJogakResult(
+        Long jogakId,
+        String mogakTitle,
+        String category,
+        String title,
+        Boolean isRoutine,
+        List<String> days,
+        String color,
+        Integer achievements,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    public static DetailJogakResult of(Jogak jogak, String color, List<String> days) {
+        return new DetailJogakResult(
+                jogak.getId(),
+                jogak.getMogak().getTitle(),
+                jogak.getCategory().getName(),
+                jogak.getTitle(),
+                jogak.getIsRoutine(),
+                days,
+                color,
+                jogak.getAchievements(),
+                jogak.getStartAt(),
+                jogak.getEndAt()
+        );
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/jogak/JogakDailyJogakResult.java
+++ b/src/main/java/com/mogak/spring/service/result/jogak/JogakDailyJogakResult.java
@@ -1,0 +1,33 @@
+package com.mogak.spring.service.result.jogak;
+
+import com.mogak.spring.domain.jogak.DailyJogak;
+import com.mogak.spring.domain.jogak.Jogak;
+import com.mogak.spring.domain.jogak.Period;
+
+import java.util.List;
+
+public record JogakDailyJogakResult(
+        Long jogakId,
+        Long dailyJogakId,
+        String title,
+        String mogakTitle,
+        String category,
+        Boolean isRoutine,
+        List<Period> days,
+        Boolean isAchievement,
+        Integer achievements
+) {
+    public static JogakDailyJogakResult of(Jogak jogak, DailyJogak dailyJogak) {
+        return new JogakDailyJogakResult(
+                jogak.getId(),
+                dailyJogak.getId(),
+                dailyJogak.getTitle(),
+                jogak.getMogak().getTitle(),
+                jogak.getCategory().getName(),
+                jogak.getIsRoutine(),
+                null,
+                dailyJogak.isSuccess(),
+                jogak.getAchievements()
+        );
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/jogak/OneTimeJogakListResult.java
+++ b/src/main/java/com/mogak/spring/service/result/jogak/OneTimeJogakListResult.java
@@ -1,0 +1,21 @@
+package com.mogak.spring.service.result.jogak;
+
+import com.mogak.spring.domain.jogak.DailyJogak;
+import com.mogak.spring.domain.jogak.Jogak;
+
+import java.util.List;
+import java.util.Objects;
+
+public record OneTimeJogakListResult(int size, List<OneTimeJogakResult> jogaks) {
+    public static OneTimeJogakListResult of(List<Jogak> jogaks, List<DailyJogak> dailyJogaks) {
+        List<OneTimeJogakResult> results = jogaks.stream()
+                .map(jogak -> OneTimeJogakResult.of(jogak, hasMatchingDailyJogak(jogak, dailyJogaks)))
+                .toList();
+        return new OneTimeJogakListResult(results.size(), results);
+    }
+
+    private static boolean hasMatchingDailyJogak(Jogak jogak, List<DailyJogak> dailyJogaks) {
+        return dailyJogaks.stream()
+                .anyMatch(dailyJogak -> Objects.equals(dailyJogak.getJogak(), jogak));
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/jogak/OneTimeJogakResult.java
+++ b/src/main/java/com/mogak/spring/service/result/jogak/OneTimeJogakResult.java
@@ -1,0 +1,31 @@
+package com.mogak.spring.service.result.jogak;
+
+import com.mogak.spring.domain.jogak.Jogak;
+
+import java.time.LocalDate;
+
+public record OneTimeJogakResult(
+        Long jogakId,
+        String mogakTitle,
+        String category,
+        String title,
+        Boolean isRoutine,
+        Boolean isAlreadyAdded,
+        Integer achievements,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+    public static OneTimeJogakResult of(Jogak jogak, Boolean isAlreadyAdded) {
+        return new OneTimeJogakResult(
+                jogak.getId(),
+                jogak.getMogak().getTitle(),
+                jogak.getCategory().getName(),
+                jogak.getTitle(),
+                jogak.getIsRoutine(),
+                isAlreadyAdded,
+                jogak.getAchievements(),
+                jogak.getStartAt(),
+                jogak.getEndAt()
+        );
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/jogak/RoutineJogakResult.java
+++ b/src/main/java/com/mogak/spring/service/result/jogak/RoutineJogakResult.java
@@ -1,0 +1,25 @@
+package com.mogak.spring.service.result.jogak;
+
+import com.mogak.spring.domain.jogak.DailyJogak;
+
+import java.time.LocalDate;
+
+public record RoutineJogakResult(
+        Long dailyJogakId,
+        LocalDate date,
+        Boolean isAchievement,
+        String title
+) {
+    public static RoutineJogakResult from(DailyJogak dailyJogak) {
+        return new RoutineJogakResult(
+                dailyJogak.getId(),
+                dailyJogak.getTargetDate(),
+                dailyJogak.isSuccess(),
+                dailyJogak.getTitle()
+        );
+    }
+
+    public static RoutineJogakResult futureFrom(LocalDate date, String title) {
+        return new RoutineJogakResult(-1L, date, false, title);
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/modarat/ModaratDetailResult.java
+++ b/src/main/java/com/mogak/spring/service/result/modarat/ModaratDetailResult.java
@@ -1,0 +1,20 @@
+package com.mogak.spring.service.result.modarat;
+
+import com.mogak.spring.domain.mogak.MogakCategory;
+
+import java.util.List;
+
+public record ModaratDetailResult(
+        Long id,
+        String title,
+        String color,
+        List<MogakInModaratResult> mogaks
+) {
+    public record MogakInModaratResult(
+            String title,
+            MogakCategory bigCategory,
+            String smallCategory,
+            String color
+    ) {
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/modarat/ModaratResult.java
+++ b/src/main/java/com/mogak/spring/service/result/modarat/ModaratResult.java
@@ -1,0 +1,4 @@
+package com.mogak.spring.service.result.modarat;
+
+public record ModaratResult(Long id, String title, String color) {
+}

--- a/src/main/java/com/mogak/spring/service/result/mogak/GetJogakResult.java
+++ b/src/main/java/com/mogak/spring/service/result/mogak/GetJogakResult.java
@@ -1,0 +1,18 @@
+package com.mogak.spring.service.result.mogak;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GetJogakResult(
+        Long jogakId,
+        String mogakTitle,
+        String category,
+        String title,
+        Boolean isRoutine,
+        List<String> days,
+        Boolean isAlreadyAdded,
+        Integer achievements,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+}

--- a/src/main/java/com/mogak/spring/service/result/mogak/GetMogakListResult.java
+++ b/src/main/java/com/mogak/spring/service/result/mogak/GetMogakListResult.java
@@ -1,0 +1,9 @@
+package com.mogak.spring.service.result.mogak;
+
+import java.util.List;
+
+public record GetMogakListResult(
+        List<GetMogakResult> mogaks,
+        int size
+) {
+}

--- a/src/main/java/com/mogak/spring/service/result/mogak/GetMogakResult.java
+++ b/src/main/java/com/mogak/spring/service/result/mogak/GetMogakResult.java
@@ -1,0 +1,12 @@
+package com.mogak.spring.service.result.mogak;
+
+import com.mogak.spring.domain.mogak.MogakCategory;
+
+public record GetMogakResult(
+        Long id,
+        String title,
+        MogakCategory bigCategory,
+        String smallCategory,
+        String color
+) {
+}

--- a/src/main/java/com/mogak/spring/service/result/post/NetworkCommentResult.java
+++ b/src/main/java/com/mogak/spring/service/result/post/NetworkCommentResult.java
@@ -1,0 +1,14 @@
+package com.mogak.spring.service.result.post;
+
+import java.time.LocalDateTime;
+
+public record NetworkCommentResult(
+        Long commentId,
+        String nickname,
+        String contents,
+        LocalDateTime createdAt
+) {
+    public static NetworkCommentResult of(Long commentId, String nickname, String contents, LocalDateTime createdAt) {
+        return new NetworkCommentResult(commentId, nickname, contents, createdAt);
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/post/NetworkFeedPostResult.java
+++ b/src/main/java/com/mogak/spring/service/result/post/NetworkFeedPostResult.java
@@ -1,0 +1,25 @@
+package com.mogak.spring.service.result.post;
+
+import java.util.List;
+
+public record NetworkFeedPostResult(
+        Long postId,
+        String userName,
+        String userJob,
+        String contents,
+        List<String> imgUrls,
+        int commentCnt,
+        int likeCnt
+) {
+    public static NetworkFeedPostResult of(
+            Long postId,
+            String userName,
+            String userJob,
+            String contents,
+            List<String> imgUrls,
+            int commentCnt,
+            int likeCnt
+    ) {
+        return new NetworkFeedPostResult(postId, userName, userJob, contents, imgUrls, commentCnt, likeCnt);
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/post/NetworkUserResult.java
+++ b/src/main/java/com/mogak/spring/service/result/post/NetworkUserResult.java
@@ -1,0 +1,10 @@
+package com.mogak.spring.service.result.post;
+
+public record NetworkUserResult(
+        String nickname,
+        String job
+) {
+    public static NetworkUserResult of(String nickname, String job) {
+        return new NetworkUserResult(nickname, job);
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/post/PacemakerPostResult.java
+++ b/src/main/java/com/mogak/spring/service/result/post/PacemakerPostResult.java
@@ -1,0 +1,23 @@
+package com.mogak.spring.service.result.post;
+
+import java.util.List;
+
+public record PacemakerPostResult(
+        NetworkUserResult user,
+        String contents,
+        List<String> imgUrls,
+        List<NetworkCommentResult> comments,
+        int likeCnt,
+        int viewCnt
+) {
+    public static PacemakerPostResult of(
+            NetworkUserResult user,
+            String contents,
+            List<String> imgUrls,
+            List<NetworkCommentResult> comments,
+            int likeCnt,
+            int viewCnt
+    ) {
+        return new PacemakerPostResult(user, contents, imgUrls, comments, likeCnt, viewCnt);
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/post/PostSummaryResult.java
+++ b/src/main/java/com/mogak/spring/service/result/post/PostSummaryResult.java
@@ -1,0 +1,15 @@
+package com.mogak.spring.service.result.post;
+
+import java.time.LocalDate;
+
+public record PostSummaryResult(
+        Long postId,
+        Long mogakId,
+        Long jogakId,
+        Long dailyJogakId,
+        LocalDate targetDate,
+        String contents,
+        String thumbnailUrl,
+        int likeCnt
+) {
+}

--- a/src/main/java/com/mogak/spring/service/result/user/UserCreateResult.java
+++ b/src/main/java/com/mogak/spring/service/result/user/UserCreateResult.java
@@ -1,0 +1,6 @@
+package com.mogak.spring.service.result.user;
+
+import com.mogak.spring.jwt.JwtTokens;
+
+public record UserCreateResult(Long userId, String nickname, JwtTokens tokens) {
+}

--- a/src/main/java/com/mogak/spring/service/result/user/UserProfileResult.java
+++ b/src/main/java/com/mogak/spring/service/result/user/UserProfileResult.java
@@ -1,0 +1,4 @@
+package com.mogak.spring.service.result.user;
+
+public record UserProfileResult(String nickname, String job, String imgUrl) {
+}

--- a/src/main/java/com/mogak/spring/web/controller/AuthController.java
+++ b/src/main/java/com/mogak/spring/web/controller/AuthController.java
@@ -6,6 +6,8 @@ import com.mogak.spring.domain.user.SocialProvider;
 import com.mogak.spring.jwt.AuthenticatedUser;
 import com.mogak.spring.jwt.JwtTokens;
 import com.mogak.spring.service.AuthService;
+import com.mogak.spring.service.result.auth.SocialLoginResult;
+import com.mogak.spring.service.result.auth.WithdrawResult;
 import com.mogak.spring.web.dto.authdto.AppleLoginRequest;
 import com.mogak.spring.web.dto.authdto.AppleLoginResponse;
 import com.mogak.spring.web.dto.authdto.AuthResponse;
@@ -40,8 +42,9 @@ public class AuthController {
             responses = {@ApiResponse(responseCode = "200", description = "로그인 성공"),})
     @PostMapping("/login")
     public ResponseEntity<BaseResponse<AppleLoginResponse>> loginApple(@RequestBody AppleLoginRequest request) {
-        AppleLoginResponse response = authService.appleLogin(request);
-        return ResponseEntity.status(HttpStatus.OK).body(new BaseResponse<>(response));
+        SocialLoginResult result = authService.appleLogin(request);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BaseResponse<>(new AppleLoginResponse(result.isRegistered(), result.userId(), result.tokens())));
     }
 
     @Operation(
@@ -69,8 +72,9 @@ public class AuthController {
             @PathVariable String provider,
             @RequestBody SocialLoginRequest request
     ) {
-        SocialLoginResponse response = authService.socialLogin(SocialProvider.from(provider), request);
-        return ResponseEntity.status(HttpStatus.OK).body(new BaseResponse<>(response));
+        SocialLoginResult result = authService.socialLogin(SocialProvider.from(provider), request);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(new BaseResponse<>(new SocialLoginResponse(result.isRegistered(), result.userId(), result.tokens())));
     }
 
     /**
@@ -103,7 +107,8 @@ public class AuthController {
             responses = {@ApiResponse(responseCode = "200", description = "회원퇄퇴 성공"),})
     @PostMapping("/withdraw")
     public ResponseEntity<BaseResponse<AuthResponse.WithdrawDto>> withdrawUser(@AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
-        AuthResponse.WithdrawDto withdrawDto = authService.deleteUser(authenticatedUser.getUserId());
-        return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponse<>(withdrawDto));
+        WithdrawResult result = authService.deleteUser(authenticatedUser.getUserId());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new BaseResponse<>(new AuthResponse.WithdrawDto(result.deleted())));
     }
 }

--- a/src/main/java/com/mogak/spring/web/controller/FollowController.java
+++ b/src/main/java/com/mogak/spring/web/controller/FollowController.java
@@ -5,6 +5,8 @@ import com.mogak.spring.global.BaseResponse;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.jwt.AuthenticatedUser;
 import com.mogak.spring.service.FollowService;
+import com.mogak.spring.service.result.follow.FollowCountResult;
+import com.mogak.spring.service.result.follow.FollowUserResult;
 import com.mogak.spring.web.dto.userdto.FollowRequestDto.CountDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -78,7 +80,8 @@ public class FollowController {
             })
     @GetMapping("counts/{nickname}")
     public ResponseEntity<BaseResponse<CountDto>> getFollowCount(@PathVariable String nickname) {
-        return ResponseEntity.ok(new BaseResponse<>(followService.getFollowCount(nickname)));
+        FollowCountResult result = followService.getFollowCount(nickname);
+        return ResponseEntity.ok(new BaseResponse<>(new CountDto(result.mentorCnt(), result.motoCnt())));
     }
 
     @Operation(summary = "모토 조회", description = "유저를 팔로우 중인 모토들을 조회 합니다",
@@ -93,7 +96,8 @@ public class FollowController {
             })
     @GetMapping("{nickname}/motos")
     public ResponseEntity<BaseResponse<List<UserDto>>> getMotoList(@PathVariable String nickname) {
-        return ResponseEntity.ok(new BaseResponse<>(followService.getMotoList(nickname)));
+        List<FollowUserResult> results = followService.getMotoList(nickname);
+        return ResponseEntity.ok(new BaseResponse<>(results.stream().map(this::toUserDto).toList()));
     }
 
     @Operation(summary = "멘토 조회", description = "유저가 팔로우 중인 멘토들을 조회 합니다",
@@ -108,7 +112,12 @@ public class FollowController {
             })
     @GetMapping("{nickname}/mentors")
     public ResponseEntity<BaseResponse<List<UserDto>>> getMentorList(@PathVariable String nickname) {
-        return ResponseEntity.ok(new BaseResponse<>(followService.getMentorList(nickname)));
+        List<FollowUserResult> results = followService.getMentorList(nickname);
+        return ResponseEntity.ok(new BaseResponse<>(results.stream().map(this::toUserDto).toList()));
+    }
+
+    private UserDto toUserDto(FollowUserResult result) {
+        return new UserDto(result.nickname(), result.job());
     }
     
 }

--- a/src/main/java/com/mogak/spring/web/controller/JogakController.java
+++ b/src/main/java/com/mogak/spring/web/controller/JogakController.java
@@ -5,6 +5,14 @@ import com.mogak.spring.global.BaseResponse;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.jwt.AuthenticatedUser;
 import com.mogak.spring.service.JogakService;
+import com.mogak.spring.service.result.jogak.CreateJogakResult;
+import com.mogak.spring.service.result.jogak.DailyJogakListResult;
+import com.mogak.spring.service.result.jogak.DailyJogakResult;
+import com.mogak.spring.service.result.jogak.DetailJogakResult;
+import com.mogak.spring.service.result.jogak.JogakDailyJogakResult;
+import com.mogak.spring.service.result.jogak.OneTimeJogakListResult;
+import com.mogak.spring.service.result.jogak.OneTimeJogakResult;
+import com.mogak.spring.service.result.jogak.RoutineJogakResult;
 import com.mogak.spring.web.dto.jogakdto.JogakRequestDto;
 import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,7 +54,9 @@ public class JogakController {
     @PostMapping("")
     public ResponseEntity<BaseResponse<JogakResponseDto.CreateJogakDto>> create(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                  @Valid @RequestBody JogakRequestDto.CreateJogakDto createJogakDto) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponse<>(jogakService.createJogak(authenticatedUser.getUserId(), createJogakDto)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponse<>(
+                toCreateJogakDto(jogakService.createJogak(authenticatedUser.getUserId(), createJogakDto))
+        ));
     }
 
     @Operation(summary = "단일 조각 조회", description = "조각 ID를 통해 조각 정보를 조회하는 API",
@@ -59,7 +69,9 @@ public class JogakController {
     @GetMapping("/{jogakId}/detail")
     public ResponseEntity<BaseResponse<JogakResponseDto.DetailJogakDto>> getJogakDetail(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                          @PathVariable Long jogakId) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.getJogakDetail(authenticatedUser.getUserId(), jogakId)));
+        return ResponseEntity.ok(new BaseResponse<>(
+                toDetailJogakDto(jogakService.getJogakDetail(authenticatedUser.getUserId(), jogakId))
+        ));
     }
 
 
@@ -74,7 +86,9 @@ public class JogakController {
     public ResponseEntity<BaseResponse<JogakResponseDto.GetOneTimeJogakListDto>> getDailyJogaks(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
             @Parameter(description = "조회를 원하는 날짜를 입력해주시면 됩니다. format: YYYY-MM-DD", example = "2024-02-15")
             @RequestParam("date") @DateTimeFormat(iso = ISO.DATE) LocalDate date) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.getDailyJogaks(authenticatedUser.getUserId(), date)));
+        return ResponseEntity.ok(new BaseResponse<>(
+                toGetOneTimeJogakListDto(jogakService.getDailyJogaks(authenticatedUser.getUserId(), date))
+        ));
     }
 
     @Operation(summary = "일별 데일리 조각 조회", description = "일별 데일리 조각들을 조회하는 API",
@@ -88,7 +102,9 @@ public class JogakController {
     public ResponseEntity<BaseResponse<JogakResponseDto.GetDailyJogakListDto>> getDayJogaks(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
             @Parameter(description = "조회를 원하는 날짜를 입력해주시면 됩니다. format: YYYY-MM-DD", example = "2024-02-14")
             @RequestParam("date") @DateTimeFormat(iso = ISO.DATE) LocalDate date) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.getDayJogaks(authenticatedUser.getUserId(), date)));
+        return ResponseEntity.ok(new BaseResponse<>(
+                toGetDailyJogakListDto(jogakService.getDayJogaks(authenticatedUser.getUserId(), date))
+        ));
     }
 
     @Operation(summary = "주간/월간 루틴 조각 조회", description = "주간/월간 루틴 조각을 조회합니다",
@@ -104,7 +120,9 @@ public class JogakController {
             @RequestParam("startDay") @DateTimeFormat(iso = ISO.DATE) LocalDate startDay,
             @Parameter(description = "조회를 원하는 마지막 날짜를 입력. format: YYYY-MM-DD", example = "2024-02-15")
             @RequestParam("endDay") @DateTimeFormat(iso = ISO.DATE) LocalDate endDay) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.getRoutineJogaks(authenticatedUser.getUserId(), startDay, endDay)));
+        return ResponseEntity.ok(new BaseResponse<>(
+                toGetRoutineJogakDtos(jogakService.getRoutineJogaks(authenticatedUser.getUserId(), startDay, endDay))
+        ));
     }
 
     @Operation(summary = "일일 조각 시작", description = "일일 조각을 시작합니다",
@@ -120,7 +138,9 @@ public class JogakController {
     @PostMapping("{jogakId}/start")
     public ResponseEntity<BaseResponse<JogakResponseDto.JogakDailyJogakDto>> startJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                         @PathVariable Long jogakId) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.startJogak(authenticatedUser.getUserId(), jogakId)));
+        return ResponseEntity.ok(new BaseResponse<>(
+                toJogakDailyJogakDto(jogakService.startJogak(authenticatedUser.getUserId(), jogakId))
+        ));
     }
 
     @Operation(summary = "조각 성공", description = "오늘의 조각으로 등록된 조각을 성공시킵니다",
@@ -138,7 +158,9 @@ public class JogakController {
     @PutMapping("{dailyJogakId}/success")
     public ResponseEntity<BaseResponse<JogakResponseDto.JogakDailyJogakDto>> successJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                            @PathVariable Long dailyJogakId) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.successJogak(authenticatedUser.getUserId(), dailyJogakId)));
+        return ResponseEntity.ok(new BaseResponse<>(
+                toJogakDailyJogakDto(jogakService.successJogak(authenticatedUser.getUserId(), dailyJogakId))
+        ));
     }
 
     @Operation(summary = "조각 실패", description = "성공한 조각을 취소합니다",
@@ -156,7 +178,9 @@ public class JogakController {
     @PutMapping("{dailyJogakId}/fail")
     public ResponseEntity<BaseResponse<JogakResponseDto.JogakDailyJogakDto>> failJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                         @PathVariable Long dailyJogakId) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.failJogak(authenticatedUser.getUserId(), dailyJogakId)));
+        return ResponseEntity.ok(new BaseResponse<>(
+                toJogakDailyJogakDto(jogakService.failJogak(authenticatedUser.getUserId(), dailyJogakId))
+        ));
     }
 
     @Operation(summary = "조각 수정", description = "입력값을 이용해 조각을 수정합니다",
@@ -172,7 +196,9 @@ public class JogakController {
     public ResponseEntity<BaseResponse<JogakResponseDto.CreateJogakDto>> updateJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                @PathVariable Long jogakId,
                                                                @Valid @RequestBody JogakRequestDto.UpdateJogakDto updateJogakDto) {
-        return ResponseEntity.ok(new BaseResponse<>(jogakService.updateJogak(authenticatedUser.getUserId(), jogakId, updateJogakDto)));
+        return ResponseEntity.ok(new BaseResponse<>(
+                toCreateJogakDto(jogakService.updateJogak(authenticatedUser.getUserId(), jogakId, updateJogakDto))
+        ));
     }
 
     @Operation(summary = "조각 삭제", description = "조각을 삭제합니다",
@@ -188,6 +214,104 @@ public class JogakController {
                                                                @PathVariable Long jogakId) {
         jogakService.deleteJogak(authenticatedUser.getUserId(), jogakId);
         return ResponseEntity.ok(new BaseResponse<>(ErrorCode.SUCCESS));
+    }
+
+    private JogakResponseDto.CreateJogakDto toCreateJogakDto(CreateJogakResult result) {
+        return JogakResponseDto.CreateJogakDto.of(
+                result.jogakId(),
+                result.mogakTitle(),
+                result.category(),
+                result.title(),
+                result.isRoutine(),
+                result.days(),
+                result.achievements(),
+                result.startDate(),
+                result.endDate()
+        );
+    }
+
+    private JogakResponseDto.DetailJogakDto toDetailJogakDto(DetailJogakResult result) {
+        return JogakResponseDto.DetailJogakDto.of(
+                result.jogakId(),
+                result.mogakTitle(),
+                result.category(),
+                result.title(),
+                result.isRoutine(),
+                result.days(),
+                result.color(),
+                result.achievements(),
+                result.startDate(),
+                result.endDate()
+        );
+    }
+
+    private JogakResponseDto.GetDailyJogakListDto toGetDailyJogakListDto(DailyJogakListResult result) {
+        List<JogakResponseDto.GetDailyJogakDto> dailyJogaks = result.dailyJogaks().stream()
+                .map(this::toGetDailyJogakDto)
+                .toList();
+        return new JogakResponseDto.GetDailyJogakListDto(result.size(), dailyJogaks);
+    }
+
+    private JogakResponseDto.GetDailyJogakDto toGetDailyJogakDto(DailyJogakResult result) {
+        return JogakResponseDto.GetDailyJogakDto.of(
+                result.jogakId(),
+                result.dailyJogakId(),
+                result.mogakTitle(),
+                result.category(),
+                result.title(),
+                result.isRoutine(),
+                result.isAchievement()
+        );
+    }
+
+    private JogakResponseDto.GetOneTimeJogakListDto toGetOneTimeJogakListDto(OneTimeJogakListResult result) {
+        List<JogakResponseDto.GetOneTimeJogakDto> jogaks = result.jogaks().stream()
+                .map(this::toGetOneTimeJogakDto)
+                .toList();
+        return new JogakResponseDto.GetOneTimeJogakListDto(result.size(), jogaks);
+    }
+
+    private JogakResponseDto.GetOneTimeJogakDto toGetOneTimeJogakDto(OneTimeJogakResult result) {
+        return JogakResponseDto.GetOneTimeJogakDto.of(
+                result.jogakId(),
+                result.mogakTitle(),
+                result.category(),
+                result.title(),
+                result.isRoutine(),
+                result.isAlreadyAdded(),
+                result.achievements(),
+                result.startDate(),
+                result.endDate()
+        );
+    }
+
+    private List<JogakResponseDto.GetRoutineJogakDto> toGetRoutineJogakDtos(List<RoutineJogakResult> results) {
+        return results.stream()
+                .map(this::toGetRoutineJogakDto)
+                .toList();
+    }
+
+    private JogakResponseDto.GetRoutineJogakDto toGetRoutineJogakDto(RoutineJogakResult result) {
+        return JogakResponseDto.GetRoutineJogakDto.of(
+                result.dailyJogakId(),
+                result.date(),
+                result.isAchievement(),
+                result.title()
+        );
+    }
+
+    private JogakResponseDto.JogakDailyJogakDto toJogakDailyJogakDto(JogakDailyJogakResult result) {
+        return JogakResponseDto.JogakDailyJogakDto.of(
+                result.jogakId(),
+                result.dailyJogakId(),
+                result.title(),
+                result.mogakTitle(),
+                result.category(),
+                result.isRoutine(),
+                result.days(),
+                result.isAchievement(),
+                result.achievements()
+        );
     }
 
 }

--- a/src/main/java/com/mogak/spring/web/controller/ModaratController.java
+++ b/src/main/java/com/mogak/spring/web/controller/ModaratController.java
@@ -3,9 +3,11 @@ package com.mogak.spring.web.controller;
 import com.mogak.spring.jwt.AuthenticatedUser;
 import com.mogak.spring.exception.ErrorResponse;
 import com.mogak.spring.global.BaseResponse;
-import com.mogak.spring.repository.query.SingleDetailModaratDto;
 import com.mogak.spring.service.ModaratService;
+import com.mogak.spring.service.result.modarat.ModaratDetailResult;
+import com.mogak.spring.service.result.modarat.ModaratResult;
 import com.mogak.spring.web.dto.modaratdto.ModaratRequestDto;
+import com.mogak.spring.web.dto.modaratdto.ModaratResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -79,9 +81,12 @@ public class ModaratController {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @GetMapping("/{modaratId}")
-    public ResponseEntity<BaseResponse<SingleDetailModaratDto>> getSingleDetailModarat(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
-                                                                                       @PathVariable Long modaratId) {
-        return ResponseEntity.status(HttpStatus.OK).body(new BaseResponse<>(modaratService.getDetailModarat(authenticatedUser.getUserId(), modaratId)));
+    public ResponseEntity<BaseResponse<ModaratResponseDto.DetailModaratDto>> getSingleDetailModarat(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @PathVariable Long modaratId
+    ) {
+        ModaratDetailResult result = modaratService.getDetailModarat(authenticatedUser.getUserId(), modaratId);
+        return ResponseEntity.status(HttpStatus.OK).body(new BaseResponse<>(toDetailModaratDto(result)));
     }
 
     @Operation(summary = "모다라트 리스트 조회", description = "사용자의 모다라트 리스트를 조회합니다",
@@ -93,7 +98,31 @@ public class ModaratController {
             })
     @GetMapping("")
     public ResponseEntity<BaseResponse<List<ModaratDto>>> getModaratList(@AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
-        return ResponseEntity.status(HttpStatus.OK).body(new BaseResponse<>(modaratService.getModaratList(authenticatedUser.getUserId())));
+        List<ModaratResult> results = modaratService.getModaratList(authenticatedUser.getUserId());
+        return ResponseEntity.status(HttpStatus.OK).body(new BaseResponse<>(results.stream().map(this::toModaratDto).toList()));
     }
 
+    private ModaratDto toModaratDto(ModaratResult result) {
+        return new ModaratDto(result.id(), result.title(), result.color());
+    }
+
+    private ModaratResponseDto.DetailModaratDto toDetailModaratDto(ModaratDetailResult result) {
+        return new ModaratResponseDto.DetailModaratDto(
+                result.id(),
+                result.title(),
+                result.color(),
+                result.mogaks().stream()
+                        .map(this::toMogakInModaratDto)
+                        .toList()
+        );
+    }
+
+    private ModaratResponseDto.MogakInModaratDto toMogakInModaratDto(ModaratDetailResult.MogakInModaratResult result) {
+        return new ModaratResponseDto.MogakInModaratDto(
+                result.title(),
+                result.bigCategory(),
+                result.smallCategory(),
+                result.color()
+        );
+    }
 }

--- a/src/main/java/com/mogak/spring/web/controller/MogakController.java
+++ b/src/main/java/com/mogak/spring/web/controller/MogakController.java
@@ -5,6 +5,9 @@ import com.mogak.spring.global.BaseResponse;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.jwt.AuthenticatedUser;
 import com.mogak.spring.service.MogakService;
+import com.mogak.spring.service.result.mogak.GetJogakResult;
+import com.mogak.spring.service.result.mogak.GetMogakListResult;
+import com.mogak.spring.service.result.mogak.GetMogakResult;
 import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
 import com.mogak.spring.web.dto.mogakdto.MogakRequestDto;
 import com.mogak.spring.web.dto.mogakdto.MogakResponseDto;
@@ -49,7 +52,9 @@ public class MogakController {
     @PostMapping("/mogaks")
     public ResponseEntity<BaseResponse<MogakResponseDto.GetMogakDto>> createMogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                   @Valid @RequestBody MogakRequestDto.CreateDto request) {
-        return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponse<>(mogakService.create(authenticatedUser.getUserId(), request)));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponse<>(
+                toGetMogakDto(mogakService.create(authenticatedUser.getUserId(), request))
+        ));
     }
 
 //    @Operation(summary = "모각 달성", description = "해당하는 모각을 달성합니다",
@@ -76,7 +81,9 @@ public class MogakController {
     @PutMapping("/mogaks")
     public ResponseEntity<BaseResponse<MogakResponseDto.GetMogakDto>> updateMogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                   @Valid @RequestBody MogakRequestDto.UpdateDto request) {
-        return ResponseEntity.ok(new BaseResponse<>(mogakService.updateMogak(authenticatedUser.getUserId(), request)));
+        return ResponseEntity.ok(new BaseResponse<>(
+                toGetMogakDto(mogakService.updateMogak(authenticatedUser.getUserId(), request))
+        ));
     }
 
     @Operation(summary = "모각 조회", description = "입력값을 이용해 모각을 조회합니다",
@@ -89,7 +96,9 @@ public class MogakController {
     @GetMapping("/{modaratId}/mogaks")
     public ResponseEntity<BaseResponse<MogakResponseDto.GetMogakListDto>> getMogakList(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                        @PathVariable Long modaratId) {
-            return ResponseEntity.ok(new BaseResponse<>(mogakService.getMogakDtoList(authenticatedUser.getUserId(), modaratId)));
+            return ResponseEntity.ok(new BaseResponse<>(
+                    toGetMogakListDto(mogakService.getMogakDtoList(authenticatedUser.getUserId(), modaratId))
+            ));
     }
 
     @Operation(summary = "모각 삭제", description = "모각을 삭제합니다",
@@ -124,6 +133,46 @@ public class MogakController {
             @PathVariable Long mogakId,
             @Parameter(description = "조회를 원하는 날짜를 입력해주시면 됩니다. 오늘 날짜를 주로 입력하시면 됩니다. format: YYYY-MM-DD", example = "2024-02-15")
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-        return ResponseEntity.ok(new BaseResponse<>(mogakService.getJogaks(authenticatedUser.getUserId(), mogakId, date)));
+        return ResponseEntity.ok(new BaseResponse<>(
+                toGetJogakDtos(mogakService.getJogaks(authenticatedUser.getUserId(), mogakId, date))
+        ));
+    }
+
+    private MogakResponseDto.GetMogakDto toGetMogakDto(GetMogakResult result) {
+        return new MogakResponseDto.GetMogakDto(
+                result.id(),
+                result.title(),
+                result.bigCategory(),
+                result.smallCategory(),
+                result.color()
+        );
+    }
+
+    private MogakResponseDto.GetMogakListDto toGetMogakListDto(GetMogakListResult result) {
+        List<MogakResponseDto.GetMogakDto> mogaks = result.mogaks().stream()
+                .map(this::toGetMogakDto)
+                .toList();
+        return new MogakResponseDto.GetMogakListDto(mogaks, result.size());
+    }
+
+    private List<JogakResponseDto.GetJogakDto> toGetJogakDtos(List<GetJogakResult> results) {
+        return results.stream()
+                .map(this::toGetJogakDto)
+                .toList();
+    }
+
+    private JogakResponseDto.GetJogakDto toGetJogakDto(GetJogakResult result) {
+        return JogakResponseDto.GetJogakDto.of(
+                result.jogakId(),
+                result.mogakTitle(),
+                result.category(),
+                result.title(),
+                result.isRoutine(),
+                result.days(),
+                result.isAlreadyAdded(),
+                result.achievements(),
+                result.startDate(),
+                result.endDate()
+        );
     }
 }

--- a/src/main/java/com/mogak/spring/web/controller/NetworkController.java
+++ b/src/main/java/com/mogak/spring/web/controller/NetworkController.java
@@ -6,9 +6,15 @@ import com.mogak.spring.global.BaseResponse;
 import com.mogak.spring.jwt.AuthenticatedUser;
 import com.mogak.spring.service.PostLikeService;
 import com.mogak.spring.service.PostService;
+import com.mogak.spring.service.result.post.NetworkCommentResult;
+import com.mogak.spring.service.result.post.NetworkFeedPostResult;
+import com.mogak.spring.service.result.post.NetworkUserResult;
+import com.mogak.spring.service.result.post.PacemakerPostResult;
+import com.mogak.spring.web.dto.commentdto.CommentResponseDto;
 import com.mogak.spring.web.dto.postdto.PostLikeRequestDto;
 import com.mogak.spring.web.dto.postdto.PostResponseDto;
 import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkPostDto;
+import com.mogak.spring.web.dto.userdto.UserResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -71,7 +77,10 @@ public class NetworkController {
             @RequestParam int cursor,
             @RequestParam int size
     ) {
-        return ResponseEntity.ok(new BaseResponse<>(postService.getPacemakerPosts(authenticatedUser.getUserId(), cursor, size)));
+        List<NetworkPostDto> posts = postService.getPacemakerPosts(authenticatedUser.getUserId(), cursor, size).stream()
+                .map(this::toNetworkPostDto)
+                .toList();
+        return ResponseEntity.ok(new BaseResponse<>(posts));
     }
 
     //네트워킹 전체조회
@@ -95,8 +104,47 @@ public class NetworkController {
             @RequestParam(value = "page", defaultValue = "0") int page, @RequestParam(value = "size") int size,
             @RequestParam(value = "sort", defaultValue = "createdAt", required = false) String sort, @RequestParam(value = "address", required = false) String address
             /*@RequestParam(value = "category", defaultValue="all", required = false) List<String> categoryList,*/) {
-        Slice<PostResponseDto.GetAllNetworkDto> posts = postService.getNetworkPosts(authenticatedUser.getUserId(), page, size, sort, address);
+        Slice<PostResponseDto.GetAllNetworkDto> posts = postService.getNetworkPosts(authenticatedUser.getUserId(), page, size, sort, address)
+                .map(this::toGetAllNetworkDto);
         return ResponseEntity.ok(new BaseResponse<>(posts));
+    }
+
+    private NetworkPostDto toNetworkPostDto(PacemakerPostResult result) {
+        return NetworkPostDto.of(
+                toUserDto(result.user()),
+                result.contents(),
+                result.imgUrls(),
+                result.comments().stream()
+                        .map(this::toNetworkCommentDto)
+                        .toList(),
+                result.likeCnt(),
+                result.viewCnt()
+        );
+    }
+
+    private UserResponseDto.UserDto toUserDto(NetworkUserResult result) {
+        return new UserResponseDto.UserDto(result.nickname(), result.job());
+    }
+
+    private CommentResponseDto.NetworkCommentDto toNetworkCommentDto(NetworkCommentResult result) {
+        return CommentResponseDto.NetworkCommentDto.of(
+                result.commentId(),
+                result.nickname(),
+                result.contents(),
+                result.createdAt()
+        );
+    }
+
+    private PostResponseDto.GetAllNetworkDto toGetAllNetworkDto(NetworkFeedPostResult result) {
+        return PostResponseDto.GetAllNetworkDto.of(
+                result.postId(),
+                result.userName(),
+                result.userJob(),
+                result.contents(),
+                result.imgUrls(),
+                result.commentCnt(),
+                result.likeCnt()
+        );
     }
 
 

--- a/src/main/java/com/mogak/spring/web/controller/PostController.java
+++ b/src/main/java/com/mogak/spring/web/controller/PostController.java
@@ -8,6 +8,7 @@ import com.mogak.spring.jwt.AuthenticatedUser;
 import com.mogak.spring.service.PostService;
 import com.mogak.spring.service.StorageCleanupService;
 import com.mogak.spring.service.StorageService;
+import com.mogak.spring.service.result.post.PostSummaryResult;
 import com.mogak.spring.web.dto.postdto.PostRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -93,7 +94,8 @@ public class PostController {
                                                                        @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                        @RequestParam(value = "page", defaultValue = "0") int page,
                                                                        @RequestParam(value = "size") int size) {
-        Slice<GetPostDto> posts = postService.getAllPosts(authenticatedUser.getUserId(), page, mogakId, size);
+        Slice<GetPostDto> posts = postService.getAllPosts(authenticatedUser.getUserId(), page, mogakId, size)
+                .map(this::toGetPostDto);
         return ResponseEntity.ok(new BaseResponse<>(posts));
     }
 
@@ -158,6 +160,19 @@ public class PostController {
                                                                   @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
         postService.delete(authenticatedUser.getUserId(), postId);
         return ResponseEntity.ok(new BaseResponse<>(DeletePostDto.deletedResponse()));
+    }
+
+    private GetPostDto toGetPostDto(PostSummaryResult result) {
+        return GetPostDto.of(
+                result.postId(),
+                result.mogakId(),
+                result.jogakId(),
+                result.dailyJogakId(),
+                result.targetDate(),
+                result.contents(),
+                result.thumbnailUrl(),
+                result.likeCnt()
+        );
     }
 
 }

--- a/src/main/java/com/mogak/spring/web/controller/UserController.java
+++ b/src/main/java/com/mogak/spring/web/controller/UserController.java
@@ -7,6 +7,8 @@ import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.jwt.AuthenticatedUser;
 import com.mogak.spring.service.StorageService;
 import com.mogak.spring.service.UserService;
+import com.mogak.spring.service.result.user.UserCreateResult;
+import com.mogak.spring.service.result.user.UserProfileResult;
 import com.mogak.spring.web.dto.userdto.UserRequestDto;
 import com.mogak.spring.web.dto.userdto.UserResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -69,8 +71,12 @@ public class UserController {
         } else {
             uploadImageDto = storageService.uploadProfileImg(multipartFile, dirName);
         }
-        UserResponseDto.CreateDto createDto = userService.create(authenticatedUser.getUserId(), request, uploadImageDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponse<>(createDto));
+        UserCreateResult result = userService.create(authenticatedUser.getUserId(), request, uploadImageDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(new BaseResponse<>(new UserResponseDto.CreateDto(
+                result.userId(),
+                result.nickname(),
+                result.tokens()
+        )));
     }
 
     @Operation(summary = "임시 로그인", description = "입력한 이메일로 로그인을 시도합니다",
@@ -96,8 +102,12 @@ public class UserController {
             })
     @GetMapping("/profile")
     public ResponseEntity<BaseResponse<UserResponseDto.GetUserDto>> getUserProfile(@AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
-        UserResponseDto.GetUserDto getUserDto = userService.getUserProfile(authenticatedUser.getUserId());
-        return ResponseEntity.status(HttpStatus.OK).body(new BaseResponse<>(getUserDto));
+        UserProfileResult result = userService.getUserProfile(authenticatedUser.getUserId());
+        return ResponseEntity.status(HttpStatus.OK).body(new BaseResponse<>(new UserResponseDto.GetUserDto(
+                result.nickname(),
+                result.job(),
+                result.imgUrl()
+        )));
     }
 
 

--- a/src/main/java/com/mogak/spring/web/dto/modaratdto/ModaratResponseDto.java
+++ b/src/main/java/com/mogak/spring/web/dto/modaratdto/ModaratResponseDto.java
@@ -1,11 +1,30 @@
 package com.mogak.spring.web.dto.modaratdto;
 
 import com.mogak.spring.domain.modarat.Modarat;
+import com.mogak.spring.domain.mogak.MogakCategory;
+
+import java.util.List;
 
 public class ModaratResponseDto {
     public record ModaratDto(Long id, String title, String color) {
         public static ModaratDto from(Modarat modarat) {
             return new ModaratDto(modarat.getId(), modarat.getTitle(), modarat.getColor());
         }
+    }
+
+    public record DetailModaratDto(
+            Long id,
+            String title,
+            String color,
+            List<MogakInModaratDto> mogakDtoList
+    ) {
+    }
+
+    public record MogakInModaratDto(
+            String title,
+            MogakCategory bigCategory,
+            String smallCategory,
+            String color
+    ) {
     }
 }

--- a/src/test/java/com/mogak/spring/config/SecurityConfigTest.java
+++ b/src/test/java/com/mogak/spring/config/SecurityConfigTest.java
@@ -10,15 +10,15 @@ import com.mogak.spring.jwt.JwtTokens;
 import com.mogak.spring.security.ApiAccessDeniedHandler;
 import com.mogak.spring.security.ApiAuthenticationEntryPoint;
 import com.mogak.spring.security.SecurityAuthority;
+import com.mogak.spring.service.result.auth.SocialLoginResult;
+import com.mogak.spring.service.result.user.UserCreateResult;
 import com.mogak.spring.service.AuthService;
 import com.mogak.spring.service.StorageService;
 import com.mogak.spring.service.UserService;
 import com.mogak.spring.web.controller.AuthController;
 import com.mogak.spring.web.controller.UserController;
 import com.mogak.spring.web.dto.authdto.SocialLoginRequest;
-import com.mogak.spring.web.dto.authdto.SocialLoginResponse;
 import com.mogak.spring.web.dto.userdto.UserRequestDto;
-import com.mogak.spring.web.dto.userdto.UserResponseDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -127,7 +127,7 @@ class SecurityConfigTest {
     @DisplayName("공급자별 소셜 로그인 API는 토큰 없이 호출할 수 있다")
     void socialLoginIsPublic() throws Exception {
         when(authService.socialLogin(any(), any(SocialLoginRequest.class)))
-                .thenReturn(new SocialLoginResponse(false, 10L, new JwtTokens("access-token", "refresh-token")));
+                .thenReturn(new SocialLoginResult(false, 10L, new JwtTokens("access-token", "refresh-token")));
 
         mockMvc.perform(post("/api/auth/google/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -160,7 +160,7 @@ class SecurityConfigTest {
     @DisplayName("ROLE_PENDING access token은 회원 등록 API에 접근할 수 있다")
     void joinAllowsPendingRole() throws Exception {
         when(userService.create(anyLong(), any(UserRequestDto.CreateUserDto.class), any(UserRequestDto.UploadImageDto.class)))
-                .thenReturn(new UserResponseDto.CreateDto(10L, "tester", new JwtTokens("access-token", "refresh-token")));
+                .thenReturn(new UserCreateResult(10L, "tester", new JwtTokens("access-token", "refresh-token")));
 
         mockMvc.perform(joinRequest(SecurityAuthority.PENDING.getAuthority()))
                 .andExpect(status().isCreated())

--- a/src/test/java/com/mogak/spring/integration/CoreFlowIntegrationTest.java
+++ b/src/test/java/com/mogak/spring/integration/CoreFlowIntegrationTest.java
@@ -14,11 +14,15 @@ import com.mogak.spring.service.JogakService;
 import com.mogak.spring.service.MogakService;
 import com.mogak.spring.service.StorageService;
 import com.mogak.spring.service.UserService;
+import com.mogak.spring.service.result.jogak.CreateJogakResult;
+import com.mogak.spring.service.result.jogak.DailyJogakResult;
+import com.mogak.spring.service.result.jogak.DailyJogakListResult;
+import com.mogak.spring.service.result.jogak.JogakDailyJogakResult;
+import com.mogak.spring.service.result.jogak.RoutineJogakResult;
+import com.mogak.spring.service.result.mogak.GetMogakResult;
 import com.mogak.spring.support.TestFixtureFactory;
 import com.mogak.spring.web.dto.jogakdto.JogakRequestDto;
-import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
 import com.mogak.spring.web.dto.mogakdto.MogakRequestDto;
-import com.mogak.spring.web.dto.mogakdto.MogakResponseDto;
 import com.mogak.spring.web.dto.userdto.UserRequestDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -77,14 +81,14 @@ class CoreFlowIntegrationTest {
         Modarat modarat = modaratRepository.save(TestFixtureFactory.modarat(null, savedUser, "메인 모다라트", "#1111"));
         Long userId = savedUser.getId();
 
-        MogakResponseDto.GetMogakDto mogak = mogakService.create(
+        GetMogakResult mogak = mogakService.create(
                 userId,
                 new MogakRequestDto.CreateDto(modarat.getId(), "정보처리기사", category.getName(), "필기", "#1234")
         );
 
-        JogakResponseDto.CreateJogakDto createdJogak = jogakService.createJogak(userId, createOneTimeJogakRequest(mogak.id(), "문제풀이", LocalDate.now()));
-        JogakResponseDto.JogakDailyJogakDto started = jogakService.startJogak(userId, createdJogak.jogakId());
-        JogakResponseDto.JogakDailyJogakDto succeeded = jogakService.successJogak(userId, started.dailyJogakId());
+        CreateJogakResult createdJogak = jogakService.createJogak(userId, createOneTimeJogakRequest(mogak.id(), "문제풀이", LocalDate.now()));
+        JogakDailyJogakResult started = jogakService.startJogak(userId, createdJogak.jogakId());
+        JogakDailyJogakResult succeeded = jogakService.successJogak(userId, started.dailyJogakId());
 
         Jogak persistedJogak = jogakRepository.findById(createdJogak.jogakId()).orElseThrow();
         DailyJogak persistedDailyJogak = dailyJogakRepository.findById(started.dailyJogakId()).orElseThrow();
@@ -110,21 +114,21 @@ class CoreFlowIntegrationTest {
                 new MogakRequestDto.CreateDto(modarat.getId(), "루틴 모각", category.getName(), "반복", "#1234")
         ).id()).orElseThrow();
 
-        JogakResponseDto.CreateJogakDto createdJogak = jogakService.createJogak(user.getId(), createRoutineJogakRequest(
+        CreateJogakResult createdJogak = jogakService.createJogak(user.getId(), createRoutineJogakRequest(
                 mogak.getId(),
                 "루틴 조각",
                 LocalDate.now(),
                 List.of(LocalDate.now().getDayOfWeek().name(), futureDate.getDayOfWeek().name())
         ));
 
-        JogakResponseDto.GetDailyJogakListDto todayResult = jogakService.getDayJogaks(user.getId(), LocalDate.now());
-        JogakResponseDto.GetDailyJogakListDto futureResult = jogakService.getDayJogaks(user.getId(), futureDate);
-        List<JogakResponseDto.GetRoutineJogakDto> routineRange = jogakService.getRoutineJogaks(user.getId(), LocalDate.now().minusDays(1), futureDate.plusDays(1));
+        DailyJogakListResult todayResult = jogakService.getDayJogaks(user.getId(), LocalDate.now());
+        DailyJogakListResult futureResult = jogakService.getDayJogaks(user.getId(), futureDate);
+        List<RoutineJogakResult> routineRange = jogakService.getRoutineJogaks(user.getId(), LocalDate.now().minusDays(1), futureDate.plusDays(1));
 
         assertThat(createdJogak.isRoutine()).isTrue();
-        assertThat(todayResult.dailyJogaks()).extracting(JogakResponseDto.GetDailyJogakDto::title).contains("루틴 조각");
-        assertThat(futureResult.dailyJogaks()).extracting(JogakResponseDto.GetDailyJogakDto::title).contains("루틴 조각");
-        assertThat(routineRange).extracting(JogakResponseDto.GetRoutineJogakDto::title).contains("루틴 조각");
+        assertThat(todayResult.dailyJogaks()).extracting(DailyJogakResult::title).contains("루틴 조각");
+        assertThat(futureResult.dailyJogaks()).extracting(DailyJogakResult::title).contains("루틴 조각");
+        assertThat(routineRange).extracting(RoutineJogakResult::title).contains("루틴 조각");
     }
 
     @Test
@@ -136,13 +140,13 @@ class CoreFlowIntegrationTest {
         ensureStandardPeriods();
         User user = userRepository.save(TestFixtureFactory.user(null, "delete@test.com", "delete-user", job, address));
         Modarat modarat = modaratRepository.save(TestFixtureFactory.modarat(null, user, "메인 모다라트", "#1111"));
-        MogakResponseDto.GetMogakDto mogak = mogakService.create(
+        GetMogakResult mogak = mogakService.create(
                 user.getId(),
                 new MogakRequestDto.CreateDto(modarat.getId(), "삭제 대상", category.getName(), "정리", "#1234")
         );
 
-        JogakResponseDto.CreateJogakDto createdJogak = jogakService.createJogak(user.getId(), createOneTimeJogakRequest(mogak.id(), "임시 조각", LocalDate.now()));
-        JogakResponseDto.JogakDailyJogakDto started = jogakService.startJogak(user.getId(), createdJogak.jogakId());
+        CreateJogakResult createdJogak = jogakService.createJogak(user.getId(), createOneTimeJogakRequest(mogak.id(), "임시 조각", LocalDate.now()));
+        JogakDailyJogakResult started = jogakService.startJogak(user.getId(), createdJogak.jogakId());
 
         mogakService.deleteMogak(user.getId(), mogak.id());
         entityManager.flush();

--- a/src/test/java/com/mogak/spring/integration/ListQueryCountIntegrationTest.java
+++ b/src/test/java/com/mogak/spring/integration/ListQueryCountIntegrationTest.java
@@ -32,12 +32,13 @@ import com.mogak.spring.service.MogakService;
 import com.mogak.spring.service.PostCommentService;
 import com.mogak.spring.service.PostService;
 import com.mogak.spring.service.StorageService;
+import com.mogak.spring.service.result.mogak.GetJogakResult;
+import com.mogak.spring.service.result.mogak.GetMogakListResult;
+import com.mogak.spring.service.result.mogak.GetMogakResult;
+import com.mogak.spring.service.result.post.NetworkFeedPostResult;
+import com.mogak.spring.service.result.post.PacemakerPostResult;
+import com.mogak.spring.service.result.post.PostSummaryResult;
 import com.mogak.spring.support.TestFixtureFactory;
-import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
-import com.mogak.spring.web.dto.mogakdto.MogakResponseDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto.GetAllNetworkDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto.GetPostDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto.NetworkPostDto;
 import jakarta.persistence.EntityManager;
 import org.hibernate.SessionFactory;
 import org.hibernate.stat.Statistics;
@@ -112,18 +113,18 @@ class ListQueryCountIntegrationTest {
         savePost(writer, mogak, "three", "thumb-three");
         flushAndClear();
 
-        QueryResult<Slice<GetAllNetworkDto>> singlePostResult = countQueries(
+        QueryResult<Slice<NetworkFeedPostResult>> singlePostResult = countQueries(
                 () -> postService.getNetworkPosts(viewer.getId(), 0, 1, "createdAt", address.getName())
         );
-        QueryResult<Slice<GetAllNetworkDto>> threePostResult = countQueries(
+        QueryResult<Slice<NetworkFeedPostResult>> threePostResult = countQueries(
                 () -> postService.getNetworkPosts(viewer.getId(), 0, 3, "createdAt", address.getName())
         );
 
         assertThat(singlePostResult.value().getContent())
-                .extracting(GetAllNetworkDto::contents)
+                .extracting(NetworkFeedPostResult::contents)
                 .containsExactly("three");
         assertThat(threePostResult.value().getContent())
-                .extracting(GetAllNetworkDto::contents)
+                .extracting(NetworkFeedPostResult::contents)
                 .containsExactly("three", "two", "one");
         assertThat(threePostResult.value().getContent())
                 .allSatisfy(post -> {
@@ -149,16 +150,16 @@ class ListQueryCountIntegrationTest {
         savePost(writer, mogak, "three", "thumb-three");
         flushAndClear();
 
-        QueryResult<List<NetworkPostDto>> singlePostResult = countQueries(
+        QueryResult<List<PacemakerPostResult>> singlePostResult = countQueries(
                 () -> postService.getPacemakerPosts(viewer.getId(), 0, 1)
         );
-        QueryResult<List<NetworkPostDto>> threePostResult = countQueries(
+        QueryResult<List<PacemakerPostResult>> threePostResult = countQueries(
                 () -> postService.getPacemakerPosts(viewer.getId(), 0, 3)
         );
 
         assertThat(singlePostResult.value()).hasSize(1);
         assertThat(threePostResult.value())
-                .extracting(NetworkPostDto::contents)
+                .extracting(PacemakerPostResult::contents)
                 .containsExactly("three", "two", "one");
         assertThat(threePostResult.value())
                 .allSatisfy(post -> {
@@ -180,18 +181,18 @@ class ListQueryCountIntegrationTest {
         savePost(writer, mogak, "three", "thumb-three");
         flushAndClear();
 
-        QueryResult<Slice<GetPostDto>> singlePostResult = countQueries(
+        QueryResult<Slice<PostSummaryResult>> singlePostResult = countQueries(
                 () -> postService.getAllPosts(writer.getId(), 0, mogak.getId(), 1)
         );
-        QueryResult<Slice<GetPostDto>> threePostResult = countQueries(
+        QueryResult<Slice<PostSummaryResult>> threePostResult = countQueries(
                 () -> postService.getAllPosts(writer.getId(), 0, mogak.getId(), 3)
         );
 
         assertThat(singlePostResult.value().getContent())
-                .extracting(GetPostDto::contents)
+                .extracting(PostSummaryResult::contents)
                 .containsExactly("three");
         assertThat(threePostResult.value().getContent())
-                .extracting(GetPostDto::contents)
+                .extracting(PostSummaryResult::contents)
                 .containsExactly("three", "two", "one");
         assertThat(threePostResult.value().getContent())
                 .allSatisfy(post -> {
@@ -213,18 +214,18 @@ class ListQueryCountIntegrationTest {
         mogakRepository.save(TestFixtureFactory.mogak(null, writer, largeModarat, category, "large-three", "#333333"));
         flushAndClear();
 
-        QueryResult<MogakResponseDto.GetMogakListDto> singleMogakResult = countQueries(
+        QueryResult<GetMogakListResult> singleMogakResult = countQueries(
                 () -> mogakService.getMogakDtoList(writer.getId(), smallModarat.getId())
         );
-        QueryResult<MogakResponseDto.GetMogakListDto> threeMogakResult = countQueries(
+        QueryResult<GetMogakListResult> threeMogakResult = countQueries(
                 () -> mogakService.getMogakDtoList(writer.getId(), largeModarat.getId())
         );
 
         assertThat(singleMogakResult.value().mogaks())
-                .extracting(MogakResponseDto.GetMogakDto::title)
+                .extracting(GetMogakResult::title)
                 .containsExactly("small-one");
         assertThat(threeMogakResult.value().mogaks())
-                .extracting(MogakResponseDto.GetMogakDto::title)
+                .extracting(GetMogakResult::title)
                 .containsExactlyInAnyOrder("large-one", "large-two", "large-three");
         assertThat(threeMogakResult.value().mogaks())
                 .allSatisfy(mogak -> assertThat(mogak.bigCategory().getName()).isEqualTo(category.getName()));
@@ -243,18 +244,18 @@ class ListQueryCountIntegrationTest {
         saveJogakWithPeriod(user, largeMogak, "large-three", "WEDNESDAY");
         flushAndClear();
 
-        QueryResult<List<JogakResponseDto.GetJogakDto>> singleJogakResult = countQueries(
+        QueryResult<List<GetJogakResult>> singleJogakResult = countQueries(
                 () -> mogakService.getJogaks(user.getId(), smallMogak.getId(), today)
         );
-        QueryResult<List<JogakResponseDto.GetJogakDto>> threeJogakResult = countQueries(
+        QueryResult<List<GetJogakResult>> threeJogakResult = countQueries(
                 () -> mogakService.getJogaks(user.getId(), largeMogak.getId(), today)
         );
 
         assertThat(singleJogakResult.value())
-                .extracting(JogakResponseDto.GetJogakDto::title)
+                .extracting(GetJogakResult::title)
                 .containsExactly("small-one");
         assertThat(threeJogakResult.value())
-                .extracting(JogakResponseDto.GetJogakDto::title)
+                .extracting(GetJogakResult::title)
                 .containsExactlyInAnyOrder("large-one", "large-two", "large-three");
         assertThat(threeJogakResult.value())
                 .allSatisfy(jogak -> {

--- a/src/test/java/com/mogak/spring/service/AuthServiceTest.java
+++ b/src/test/java/com/mogak/spring/service/AuthServiceTest.java
@@ -15,14 +15,13 @@ import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.jwt.JwtTokenProvider;
 import com.mogak.spring.jwt.JwtTokens;
 import com.mogak.spring.repository.*;
+import com.mogak.spring.service.result.auth.SocialLoginResult;
+import com.mogak.spring.service.result.auth.WithdrawResult;
 import com.mogak.spring.security.SecurityAuthority;
 import com.mogak.spring.support.ErrorCodeAssertions;
 import com.mogak.spring.support.TestFixtureFactory;
 import com.mogak.spring.web.dto.authdto.AppleLoginRequest;
-import com.mogak.spring.web.dto.authdto.AppleLoginResponse;
-import com.mogak.spring.web.dto.authdto.AuthResponse;
 import com.mogak.spring.web.dto.authdto.SocialLoginRequest;
-import com.mogak.spring.web.dto.authdto.SocialLoginResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -83,7 +82,7 @@ class AuthServiceTest {
         when(jwtTokenProvider.createAccessToken(1L, "user@test.com", SecurityAuthority.USER.getAuthority())).thenReturn("access-token");
         when(jwtTokenProvider.createRefreshToken(1L)).thenReturn("refresh-token");
 
-        AppleLoginResponse response = authService.appleLogin(request);
+        SocialLoginResult response = authService.appleLogin(request);
 
         assertThat(response.tokens().refreshToken()).isEqualTo("refresh-token");
         assertThat(ReflectionTestUtils.getField(user, "refreshToken")).isEqualTo("refresh-token");
@@ -104,7 +103,7 @@ class AuthServiceTest {
         when(jwtTokenProvider.createAccessToken(1L, "user@test.com", SecurityAuthority.USER.getAuthority())).thenReturn("access-token");
         when(jwtTokenProvider.createRefreshToken(1L)).thenReturn("refresh-token");
 
-        AppleLoginResponse response = authService.appleLogin(request);
+        SocialLoginResult response = authService.appleLogin(request);
 
         assertThat(response.userId()).isEqualTo(1L);
         assertThat(response.tokens().accessToken()).isEqualTo("access-token");
@@ -125,7 +124,7 @@ class AuthServiceTest {
         when(jwtTokenProvider.createAccessToken(1L, "google@test.com", SecurityAuthority.USER.getAuthority())).thenReturn("access-token");
         when(jwtTokenProvider.createRefreshToken(1L)).thenReturn("refresh-token");
 
-        SocialLoginResponse response = authService.socialLogin(SocialProvider.GOOGLE, request);
+        SocialLoginResult response = authService.socialLogin(SocialProvider.GOOGLE, request);
 
         assertThat(response.isRegistered()).isTrue();
         assertThat(response.userId()).isEqualTo(1L);
@@ -166,7 +165,7 @@ class AuthServiceTest {
         when(jwtTokenProvider.createAccessToken(2L, "new-kakao@test.com", SecurityAuthority.PENDING.getAuthority())).thenReturn("access-token");
         when(jwtTokenProvider.createRefreshToken(2L)).thenReturn("refresh-token");
 
-        SocialLoginResponse response = authService.socialLogin(SocialProvider.KAKAO, request);
+        SocialLoginResult response = authService.socialLogin(SocialProvider.KAKAO, request);
 
         assertThat(response.isRegistered()).isFalse();
         verify(socialAccountRepository).saveAndFlush(org.mockito.ArgumentMatchers.argThat(account ->
@@ -191,7 +190,7 @@ class AuthServiceTest {
         when(jwtTokenProvider.createAccessToken(3L, null, SecurityAuthority.PENDING.getAuthority())).thenReturn("access-token");
         when(jwtTokenProvider.createRefreshToken(3L)).thenReturn("refresh-token");
 
-        SocialLoginResponse response = authService.socialLogin(SocialProvider.KAKAO, request);
+        SocialLoginResult response = authService.socialLogin(SocialProvider.KAKAO, request);
 
         assertThat(response.isRegistered()).isFalse();
         assertThat(response.tokens().refreshToken()).isEqualTo("refresh-token");
@@ -301,9 +300,9 @@ class AuthServiceTest {
         when(mogakRepository.findAllByUser(user)).thenReturn(List.of(mogak));
         when(modaratRepository.findModaratsByUserId(1L)).thenReturn(List.of(modarat));
 
-        AuthResponse.WithdrawDto result = authService.deleteUser(1L);
+        WithdrawResult result = authService.deleteUser(1L);
 
-        assertThat(result.isDeleted()).isTrue();
+        assertThat(result.deleted()).isTrue();
         assertThat(user.isDeleted()).isTrue();
         assertThat(jogak.isDeleted()).isTrue();
         assertThat(mogak.isDeleted()).isTrue();

--- a/src/test/java/com/mogak/spring/service/JogakServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/JogakServiceImplTest.java
@@ -14,10 +14,14 @@ import com.mogak.spring.domain.post.PostImg;
 import com.mogak.spring.domain.user.User;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.repository.*;
+import com.mogak.spring.service.result.jogak.CreateJogakResult;
+import com.mogak.spring.service.result.jogak.DailyJogakListResult;
+import com.mogak.spring.service.result.jogak.JogakDailyJogakResult;
+import com.mogak.spring.service.result.jogak.OneTimeJogakListResult;
+import com.mogak.spring.service.result.jogak.RoutineJogakResult;
 import com.mogak.spring.support.ErrorCodeAssertions;
 import com.mogak.spring.support.TestFixtureFactory;
 import com.mogak.spring.web.dto.jogakdto.JogakRequestDto;
-import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -69,7 +73,7 @@ class JogakServiceImplTest {
         when(mogakRepository.findActiveById(2L)).thenReturn(Optional.of(mogak));
         when(jogakRepository.save(any(Jogak.class))).thenReturn(saved);
 
-        JogakResponseDto.CreateJogakDto result = jogakService.createJogak(1L, request);
+        CreateJogakResult result = jogakService.createJogak(1L, request);
 
         assertThat(result.jogakId()).isEqualTo(10L);
         assertThat(result.isRoutine()).isFalse();
@@ -97,7 +101,7 @@ class JogakServiceImplTest {
         when(periodRepository.findOneByDays("MONDAY")).thenReturn(Optional.of(monday));
         when(periodRepository.findOneByDays("TUESDAY")).thenReturn(Optional.of(tuesday));
 
-        JogakResponseDto.CreateJogakDto result = jogakService.createJogak(1L, request);
+        CreateJogakResult result = jogakService.createJogak(1L, request);
 
         assertThat(result.isRoutine()).isTrue();
         assertThat(result.days()).containsExactly("MONDAY", "TUESDAY");
@@ -197,7 +201,7 @@ class JogakServiceImplTest {
         when(userRepository.findActiveById(1L)).thenReturn(Optional.of(user));
         when(jogakRepository.findDailyRoutineJogaks(user, futureDay.getDayOfWeek().getValue())).thenReturn(List.of(routine));
 
-        JogakResponseDto.GetDailyJogakListDto result = jogakService.getDayJogaks(1L, futureDay);
+        DailyJogakListResult result = jogakService.getDayJogaks(1L, futureDay);
 
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.dailyJogaks().get(0).title()).isEqualTo("루틴 조각");
@@ -217,7 +221,7 @@ class JogakServiceImplTest {
         when(jogakRepository.findActiveOneTimeJogaksByUser(user)).thenReturn(List.of(jogak));
         when(dailyJogakRepository.findDailyJogaks(user, day)).thenReturn(List.of());
 
-        JogakResponseDto.GetOneTimeJogakListDto result = jogakService.getDailyJogaks(1L, day);
+        OneTimeJogakListResult result = jogakService.getDailyJogaks(1L, day);
 
         assertThat(result.size()).isEqualTo(1);
         assertThat(result.jogaks().get(0).title()).isEqualTo("일회성 조각");
@@ -241,7 +245,7 @@ class JogakServiceImplTest {
                 .thenReturn(Optional.empty());
         when(dailyJogakRepository.save(any(DailyJogak.class))).thenReturn(dailyJogak);
 
-        JogakResponseDto.JogakDailyJogakDto result = jogakService.startJogak(1L, 10L);
+        JogakDailyJogakResult result = jogakService.startJogak(1L, 10L);
 
         assertThat(result.dailyJogakId()).isEqualTo(100L);
         assertThat(result.achievements()).isZero();
@@ -298,7 +302,7 @@ class JogakServiceImplTest {
 
         when(dailyJogakRepository.findActiveByIdWithJogakGraph(100L)).thenReturn(Optional.of(dailyJogak));
 
-        JogakResponseDto.JogakDailyJogakDto result = jogakService.successJogak(1L, 100L);
+        JogakDailyJogakResult result = jogakService.successJogak(1L, 100L);
 
         assertThat(result.isAchievement()).isTrue();
         assertThat(result.achievements()).isEqualTo(1);
@@ -317,7 +321,7 @@ class JogakServiceImplTest {
 
         when(dailyJogakRepository.findActiveByIdWithJogakGraph(100L)).thenReturn(Optional.of(dailyJogak));
 
-        JogakResponseDto.JogakDailyJogakDto result = jogakService.failJogak(1L, 100L);
+        JogakDailyJogakResult result = jogakService.failJogak(1L, 100L);
 
         assertThat(result.isAchievement()).isFalse();
         assertThat(result.achievements()).isEqualTo(1);
@@ -439,7 +443,7 @@ class JogakServiceImplTest {
         JogakRequestDto.UpdateJogakDto request = new JogakRequestDto.UpdateJogakDto("수정 조각", false, null, null);
         when(jogakRepository.findActiveById(10L)).thenReturn(Optional.of(jogak));
 
-        JogakResponseDto.CreateJogakDto result = jogakService.updateJogak(owner.getId(), 10L, request);
+        CreateJogakResult result = jogakService.updateJogak(owner.getId(), 10L, request);
 
         assertThat(result.title()).isEqualTo("수정 조각");
         assertThat(result.isRoutine()).isFalse();
@@ -552,9 +556,9 @@ class JogakServiceImplTest {
         when(dailyJogakRepository.findDailyJogaksBetween(user, start, end)).thenReturn(List.of(pastDailyJogak));
         when(jogakRepository.findAllRoutineJogaksByUser(1L)).thenReturn(List.of(routine));
 
-        List<JogakResponseDto.GetRoutineJogakDto> result = jogakService.getRoutineJogaks(1L, start, end);
+        List<RoutineJogakResult> result = jogakService.getRoutineJogaks(1L, start, end);
 
         assertThat(result).isNotEmpty();
-        assertThat(result).extracting(JogakResponseDto.GetRoutineJogakDto::title).contains("루틴 조각");
+        assertThat(result).extracting(RoutineJogakResult::title).contains("루틴 조각");
     }
 }

--- a/src/test/java/com/mogak/spring/service/MogakServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/MogakServiceImplTest.java
@@ -10,11 +10,11 @@ import com.mogak.spring.domain.user.Job;
 import com.mogak.spring.domain.user.User;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.repository.*;
+import com.mogak.spring.service.result.mogak.GetJogakResult;
+import com.mogak.spring.service.result.mogak.GetMogakResult;
 import com.mogak.spring.support.ErrorCodeAssertions;
 import com.mogak.spring.support.TestFixtureFactory;
-import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
 import com.mogak.spring.web.dto.mogakdto.MogakRequestDto;
-import com.mogak.spring.web.dto.mogakdto.MogakResponseDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,7 +61,7 @@ class MogakServiceImplTest {
         when(categoryRepository.findMogakCategoryByName("자격증")).thenReturn(Optional.of(category));
         when(mogakRepository.save(org.mockito.ArgumentMatchers.any(Mogak.class))).thenReturn(saved);
 
-        MogakResponseDto.GetMogakDto result = mogakService.create(1L, request);
+        GetMogakResult result = mogakService.create(1L, request);
 
         assertThat(result.id()).isEqualTo(5L);
         assertThat(result.title()).isEqualTo("정보처리기사");
@@ -122,7 +122,7 @@ class MogakServiceImplTest {
 
         MogakRequestDto.UpdateDto request = new MogakRequestDto.UpdateDto(2L, "새 제목", "직무공부", "백엔드", "#9999");
 
-        MogakResponseDto.GetMogakDto result = mogakService.updateMogak(1L, request);
+        GetMogakResult result = mogakService.updateMogak(1L, request);
 
         assertThat(result.title()).isEqualTo("새 제목");
         assertThat(mogak.getBigCategory()).isEqualTo(newCategory);
@@ -224,7 +224,7 @@ class MogakServiceImplTest {
         when(jogakRepository.findAllByMogakWithFetchGraph(mogak)).thenReturn(List.of(active));
         when(dailyJogakRepository.findDailyJogaks(user, day)).thenReturn(List.of(dailyJogak));
 
-        List<JogakResponseDto.GetJogakDto> result = mogakService.getJogaks(1L, 2L, day);
+        List<GetJogakResult> result = mogakService.getJogaks(1L, 2L, day);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).jogakId()).isEqualTo(10L);

--- a/src/test/java/com/mogak/spring/service/UserServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/UserServiceImplTest.java
@@ -8,12 +8,13 @@ import com.mogak.spring.jwt.JwtTokenProvider;
 import com.mogak.spring.repository.AddressRepository;
 import com.mogak.spring.repository.JobRepository;
 import com.mogak.spring.repository.UserRepository;
+import com.mogak.spring.service.result.user.UserCreateResult;
+import com.mogak.spring.service.result.user.UserProfileResult;
 import com.mogak.spring.security.SecurityAuthority;
 import com.mogak.spring.support.ErrorCodeAssertions;
 import com.mogak.spring.support.TestFixtureFactory;
 import com.mogak.spring.util.Regex;
 import com.mogak.spring.web.dto.userdto.UserRequestDto;
-import com.mogak.spring.web.dto.userdto.UserResponseDto;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -95,7 +96,7 @@ class UserServiceImplTest {
         when(jwtTokenProvider.createAccessToken(10L, "user@test.com", SecurityAuthority.USER.getAuthority())).thenReturn("access-token");
         when(jwtTokenProvider.createRefreshToken(10L)).thenReturn("refresh-token");
 
-        UserResponseDto.CreateDto result = userService.create(10L, request, uploadImageDto);
+        UserCreateResult result = userService.create(10L, request, uploadImageDto);
 
         assertThat(result.userId()).isEqualTo(10L);
         assertThat(result.nickname()).isEqualTo("tester");
@@ -168,7 +169,7 @@ class UserServiceImplTest {
 
         when(userRepository.findActiveById(1L)).thenReturn(Optional.of(user));
 
-        UserResponseDto.GetUserDto result = userService.getUserProfile(1L);
+        UserProfileResult result = userService.getUserProfile(1L);
 
         assertThat(result.nickname()).isEqualTo("tester");
         assertThat(result.job()).isEqualTo("개발/데이터");

--- a/src/test/java/com/mogak/spring/web/controller/JogakControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/JogakControllerTest.java
@@ -6,9 +6,15 @@ import com.mogak.spring.exception.JogakException;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.jwt.JwtTokenProvider;
 import com.mogak.spring.service.JogakService;
+import com.mogak.spring.service.result.jogak.CreateJogakResult;
+import com.mogak.spring.service.result.jogak.DailyJogakListResult;
+import com.mogak.spring.service.result.jogak.DailyJogakResult;
+import com.mogak.spring.service.result.jogak.JogakDailyJogakResult;
+import com.mogak.spring.service.result.jogak.OneTimeJogakListResult;
+import com.mogak.spring.service.result.jogak.OneTimeJogakResult;
+import com.mogak.spring.service.result.jogak.RoutineJogakResult;
 import com.mogak.spring.support.SecurityContextTestHelper;
 import com.mogak.spring.web.dto.jogakdto.JogakRequestDto;
-import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -68,7 +74,7 @@ class JogakControllerTest {
     @DisplayName("조각 생성 요청이 성공하면 생성 응답 계약을 반환한다")
     void createJogakContract() throws Exception {
         when(jogakService.createJogak(eq(1L), any(JogakRequestDto.CreateJogakDto.class))).thenReturn(
-                new JogakResponseDto.CreateJogakDto(
+                new CreateJogakResult(
                         1L,
                         "정보처리기사",
                         "자격증",
@@ -112,9 +118,9 @@ class JogakControllerTest {
     @DisplayName("일회성 조각 조회 요청이 성공하면 조회 응답 계약을 반환한다")
     void getDailyJogaksContract() throws Exception {
         when(jogakService.getDailyJogaks(anyLong(), eq(LocalDate.of(2026, 3, 26)))).thenReturn(
-                new JogakResponseDto.GetOneTimeJogakListDto(
+                new OneTimeJogakListResult(
                         1,
-                        List.of(new JogakResponseDto.GetOneTimeJogakDto(
+                        List.of(new OneTimeJogakResult(
                                 1L,
                                 "정보처리기사",
                                 "자격증",
@@ -144,7 +150,7 @@ class JogakControllerTest {
     @DisplayName("루틴 조각 조회 요청이 성공하면 조회 응답 계약을 반환한다")
     void getRoutineJogaksContract() throws Exception {
         when(jogakService.getRoutineJogaks(anyLong(), eq(LocalDate.of(2026, 3, 26)), eq(LocalDate.of(2026, 3, 30)))).thenReturn(List.of(
-                new JogakResponseDto.GetRoutineJogakDto(-1L, LocalDate.of(2026, 3, 27), false, "루틴 조각")
+                new RoutineJogakResult(-1L, LocalDate.of(2026, 3, 27), false, "루틴 조각")
         ));
 
         mockMvc.perform(get("/api/modarats/mogaks/jogaks/routines")
@@ -164,9 +170,9 @@ class JogakControllerTest {
     @DisplayName("일별 데일리 조각 조회 요청이 성공하면 query parameter 날짜로 조회 응답 계약을 반환한다")
     void getDayJogaksContract() throws Exception {
         when(jogakService.getDayJogaks(anyLong(), eq(LocalDate.of(2026, 3, 26)))).thenReturn(
-                new JogakResponseDto.GetDailyJogakListDto(
+                new DailyJogakListResult(
                         1,
-                        List.of(new JogakResponseDto.GetDailyJogakDto(
+                        List.of(new DailyJogakResult(
                                 1L,
                                 10L,
                                 "정보처리기사",
@@ -194,7 +200,7 @@ class JogakControllerTest {
     @DisplayName("조각 시작 요청이 성공하면 성공 응답 계약을 반환한다")
     void startJogakContract() throws Exception {
         when(jogakService.startJogak(1L, 1L)).thenReturn(
-                new JogakResponseDto.JogakDailyJogakDto(
+                new JogakDailyJogakResult(
                         1L,
                         10L,
                         "문제풀이",
@@ -236,7 +242,7 @@ class JogakControllerTest {
     @DisplayName("조각 성공 요청이 성공하면 성공 응답 계약을 반환한다")
     void successJogakContract() throws Exception {
         when(jogakService.successJogak(1L, 10L)).thenReturn(
-                new JogakResponseDto.JogakDailyJogakDto(
+                new JogakDailyJogakResult(
                         1L,
                         10L,
                         "문제풀이",

--- a/src/test/java/com/mogak/spring/web/controller/ModaratControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/ModaratControllerTest.java
@@ -5,8 +5,8 @@ import com.mogak.spring.domain.modarat.Modarat;
 import com.mogak.spring.domain.user.User;
 import com.mogak.spring.exception.GlobalExceptionHandler;
 import com.mogak.spring.jwt.JwtTokenProvider;
-import com.mogak.spring.repository.query.SingleDetailModaratDto;
 import com.mogak.spring.service.ModaratService;
+import com.mogak.spring.service.result.modarat.ModaratDetailResult;
 import com.mogak.spring.support.SecurityContextTestHelper;
 import com.mogak.spring.support.TestFixtureFactory;
 import com.mogak.spring.web.dto.modaratdto.ModaratRequestDto;
@@ -23,6 +23,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -90,7 +92,8 @@ class ModaratControllerTest {
     @Test
     @DisplayName("모다라트 상세 조회 요청이 성공하면 userId를 서비스로 전달한다")
     void getDetailModaratForwardsUserId() throws Exception {
-        when(modaratService.getDetailModarat(eq(1L), eq(10L))).thenReturn(new SingleDetailModaratDto(10L, "메인 모다라트", "#112233"));
+        when(modaratService.getDetailModarat(eq(1L), eq(10L)))
+                .thenReturn(new ModaratDetailResult(10L, "메인 모다라트", "#112233", List.of()));
 
         mockMvc.perform(get("/api/modarats/10"))
                 .andExpect(status().isOk())

--- a/src/test/java/com/mogak/spring/web/controller/MogakControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/MogakControllerTest.java
@@ -7,10 +7,11 @@ import com.mogak.spring.exception.MogakException;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.jwt.JwtTokenProvider;
 import com.mogak.spring.service.MogakService;
+import com.mogak.spring.service.result.mogak.GetJogakResult;
+import com.mogak.spring.service.result.mogak.GetMogakListResult;
+import com.mogak.spring.service.result.mogak.GetMogakResult;
 import com.mogak.spring.support.SecurityContextTestHelper;
-import com.mogak.spring.web.dto.jogakdto.JogakResponseDto;
 import com.mogak.spring.web.dto.mogakdto.MogakRequestDto;
-import com.mogak.spring.web.dto.mogakdto.MogakResponseDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -73,7 +74,7 @@ class MogakControllerTest {
     @DisplayName("모각 생성 요청이 성공하면 생성 응답 계약을 반환한다")
     void createMogakContract() throws Exception {
         when(mogakService.create(anyLong(), any(MogakRequestDto.CreateDto.class))).thenReturn(
-                new MogakResponseDto.GetMogakDto(
+                new GetMogakResult(
                         1L,
                         "정보처리기사",
                         MogakCategory.builder().id(1).name("자격증").build(),
@@ -122,8 +123,8 @@ class MogakControllerTest {
     @DisplayName("모각 목록 조회 요청이 성공하면 목록 응답 계약을 반환한다")
     void getMogakListContract() throws Exception {
         when(mogakService.getMogakDtoList(anyLong(), eq(10L))).thenReturn(
-                new MogakResponseDto.GetMogakListDto(
-                        List.of(new MogakResponseDto.GetMogakDto(
+                new GetMogakListResult(
+                        List.of(new GetMogakResult(
                                 1L,
                                 "정보처리기사",
                                 MogakCategory.builder().id(1).name("자격증").build(),
@@ -151,7 +152,7 @@ class MogakControllerTest {
     @DisplayName("조각 목록 조회 요청이 성공하면 목록 응답 계약을 반환한다")
     void getJogaksContract() throws Exception {
         when(mogakService.getJogaks(anyLong(), eq(1L), eq(LocalDate.of(2026, 3, 26)))).thenReturn(List.of(
-                new JogakResponseDto.GetJogakDto(
+                new GetJogakResult(
                         100L,
                         "정보처리기사",
                         "자격증",
@@ -198,7 +199,7 @@ class MogakControllerTest {
     @DisplayName("모각 수정 요청이 성공하면 userId를 서비스로 전달한다")
     void updateMogakForwardsUserId() throws Exception {
         when(mogakService.updateMogak(eq(1L), any(MogakRequestDto.UpdateDto.class))).thenReturn(
-                new MogakResponseDto.GetMogakDto(
+                new GetMogakResult(
                         1L,
                         "수정된 모각",
                         MogakCategory.builder().id(1).name("자격증").build(),

--- a/src/test/java/com/mogak/spring/web/controller/NetworkControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/NetworkControllerTest.java
@@ -7,9 +7,9 @@ import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.jwt.JwtTokenProvider;
 import com.mogak.spring.service.PostLikeService;
 import com.mogak.spring.service.PostService;
+import com.mogak.spring.service.result.post.NetworkFeedPostResult;
 import com.mogak.spring.support.SecurityContextTestHelper;
 import com.mogak.spring.web.dto.postdto.PostLikeRequestDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto.GetAllNetworkDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -133,7 +133,7 @@ class NetworkControllerTest {
     @DisplayName("네트워크 게시글 조회는 기존 Slice DTO JSON 계약을 유지한다")
     void getAllPostsReturnsSliceDtoContract() throws Exception {
         SecurityContextTestHelper.setAuthentication(7L, "user@test.com", "ROLE_USER");
-        GetAllNetworkDto post = GetAllNetworkDto.of(
+        NetworkFeedPostResult post = NetworkFeedPostResult.of(
                 20L,
                 "writer",
                 "개발/데이터",
@@ -142,7 +142,7 @@ class NetworkControllerTest {
                 2,
                 5
         );
-        Slice<GetAllNetworkDto> posts = new SliceImpl<>(List.of(post), PageRequest.of(0, 10), true);
+        Slice<NetworkFeedPostResult> posts = new SliceImpl<>(List.of(post), PageRequest.of(0, 10), true);
         when(postService.getNetworkPosts(7L, 0, 10, "createdAt", "서울특별시")).thenReturn(posts);
 
         mockMvc.perform(get("/api/posts")

--- a/src/test/java/com/mogak/spring/web/controller/PostControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/PostControllerTest.java
@@ -11,11 +11,11 @@ import com.mogak.spring.jwt.JwtTokenProvider;
 import com.mogak.spring.service.PostService;
 import com.mogak.spring.service.StorageCleanupService;
 import com.mogak.spring.service.StorageService;
+import com.mogak.spring.service.result.post.PostSummaryResult;
 import com.mogak.spring.support.SecurityContextTestHelper;
 import com.mogak.spring.support.TestFixtureFactory;
 import com.mogak.spring.web.dto.postdto.PostImgRequestDto;
 import com.mogak.spring.web.dto.postdto.PostRequestDto;
-import com.mogak.spring.web.dto.postdto.PostResponseDto.GetPostDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -276,7 +276,7 @@ class PostControllerTest {
     @DisplayName("모각별 게시글 조회는 인증 사용자의 id를 서비스에 전달한다")
     void getPostListUsesAuthenticatedUserId() throws Exception {
         SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
-        Slice<GetPostDto> posts = new SliceImpl<>(List.of());
+        Slice<PostSummaryResult> posts = new SliceImpl<>(List.of());
         when(postService.getAllPosts(7L, 0, 1L, 10)).thenReturn(posts);
 
         mockMvc.perform(get("/api/mogaks/{mogakId}/posts", 1L)
@@ -291,7 +291,7 @@ class PostControllerTest {
     @DisplayName("모각별 게시글 조회는 기존 Slice DTO JSON 계약을 유지한다")
     void getPostListReturnsSliceDtoContract() throws Exception {
         SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
-        GetPostDto post = GetPostDto.of(
+        PostSummaryResult post = new PostSummaryResult(
                 11L,
                 1L,
                 2L,
@@ -301,7 +301,7 @@ class PostControllerTest {
                 "https://example.com/thumb.png",
                 4
         );
-        Slice<GetPostDto> posts = new SliceImpl<>(List.of(post), PageRequest.of(0, 10), true);
+        Slice<PostSummaryResult> posts = new SliceImpl<>(List.of(post), PageRequest.of(0, 10), true);
         when(postService.getAllPosts(7L, 0, 1L, 10)).thenReturn(posts);
 
         mockMvc.perform(get("/api/mogaks/{mogakId}/posts", 1L)

--- a/src/test/java/com/mogak/spring/web/controller/UserControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/UserControllerTest.java
@@ -7,9 +7,10 @@ import com.mogak.spring.jwt.JwtTokenProvider;
 import com.mogak.spring.service.StorageService;
 import com.mogak.spring.service.UserService;
 import com.mogak.spring.security.SecurityAuthority;
+import com.mogak.spring.service.result.user.UserCreateResult;
+import com.mogak.spring.service.result.user.UserProfileResult;
 import com.mogak.spring.support.SecurityContextTestHelper;
 import com.mogak.spring.web.dto.userdto.UserRequestDto;
-import com.mogak.spring.web.dto.userdto.UserResponseDto;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -95,7 +96,7 @@ class UserControllerTest {
     @DisplayName("회원 가입 multipart 요청이 성공하면 생성 응답 계약을 반환한다")
     void createUserMultipartContract() throws Exception {
         SecurityContextTestHelper.setAuthentication(1L, "user@test.com", SecurityAuthority.PENDING.getAuthority());
-        UserResponseDto.CreateDto response = new UserResponseDto.CreateDto(1L, "tester", null);
+        UserCreateResult response = new UserCreateResult(1L, "tester", null);
         when(userService.create(anyLong(), any(UserRequestDto.CreateUserDto.class), any(UserRequestDto.UploadImageDto.class)))
                 .thenReturn(response);
 
@@ -170,7 +171,7 @@ class UserControllerTest {
     @DisplayName("프로필 조회 요청이 성공하면 조회 응답 계약을 반환한다")
     void getUserProfileContract() throws Exception {
         SecurityContextTestHelper.setAuthentication(1L, "user@test.com", SecurityAuthority.USER.getAuthority());
-        when(userService.getUserProfile(1L)).thenReturn(new UserResponseDto.GetUserDto("tester", "개발/데이터", "https://cdn/profile.png"));
+        when(userService.getUserProfile(1L)).thenReturn(new UserProfileResult("tester", "개발/데이터", "https://cdn/profile.png"));
 
         mockMvc.perform(get("/api/users/profile"))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## 변경 내용
- Service 계층이 Web Response DTO를 직접 반환하지 않도록 service result record를 도입했습니다.
- Controller에서 service result를 API Response DTO로 조립하도록 경계를 정리했습니다.
- Auth/User, Mogak/Jogak/Modarat, Follow/Post/Network 범위별로 결과 타입과 테스트를 갱신했습니다.
- 별도 mapper 클래스는 제거하고 controller 내부 변환 메서드로 단순화했습니다.

## 검증
- sh gradlew test
- git diff --check
- JogakServiceResult / ResponseMapper / web.mapper 참조 제거 확인

Closes #160