### PR TITLE
feat(#165): 회고 등록 시 이미지 없이 생성 가능하도록 변경

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 
 ## 빠른 링크
 - [루트 가이드](../AGENTS.md)
+- [게시글 생성 API](api/post-create.md)
 - [게시글 목록 API](api/post-list.md)
 - [소셜 로그인 API](api/social-login.md)
 - [Claude Compatibility](../CLAUDE.md)

--- a/docs/api/post-create.md
+++ b/docs/api/post-create.md
@@ -1,0 +1,71 @@
+# Post Create API
+
+이 문서는 회고 생성 API의 이미지 업로드 계약을 정리한다.
+
+## Endpoint
+
+`POST /api/jogaks/{jogakId}/posts`
+
+요청은 `multipart/form-data`를 사용한다.
+
+## Request Parts
+
+| Part | Required | Meaning |
+| --- | --- | --- |
+| `request` | yes | 회고 생성 JSON |
+| `multipartFile` | no | 회고 이미지 목록 |
+
+`request` 예시:
+
+```json
+{
+  "targetDate": "2026-04-28",
+  "contents": "오늘 회고"
+}
+```
+
+이미지 파트 처리:
+- `multipartFile` part가 없어도 회고 생성은 성공한다.
+- 빈 파일 part만 전달되면 이미지 없음으로 처리한다.
+- 이미지가 없으면 storage 업로드를 호출하지 않는다.
+- 이미지가 있으면 storage 업로드 후 회고를 생성한다.
+
+## Response Contract
+
+이미지 없는 회고 생성 응답의 `imgUrls`는 빈 배열이다.
+
+```json
+{
+  "code": "success",
+  "result": {
+    "id": 1,
+    "mogakId": 1,
+    "jogakId": 2,
+    "dailyJogakId": 3,
+    "targetDate": "2026-04-28",
+    "userId": 7,
+    "contents": "오늘 회고",
+    "imgUrls": [],
+    "createdAt": "2026-04-28T12:00:00"
+  }
+}
+```
+
+목록 응답에서 이미지 없는 회고의 `thumbnailUrl`은 `null`이다.
+
+## Storage Disabled
+
+`feature.storage.enabled=false` 상태에서 실제 이미지가 포함된 요청은 실패한다.
+
+| HTTP | Code | Meaning |
+| --- | --- | --- |
+| `503` | `Z006` | 현재 서버 환경에서 storage 기능이 비활성화됨 |
+
+`503 Z006`은 모바일 클라이언트가 자동 재시도할 일반 장애가 아니라, 현재 배포 환경에서 이미지 업로드/삭제 기능이 비활성화된 상태를 의미한다.
+
+클라이언트 처리 기준:
+- 이미지 없는 회고 생성 흐름은 계속 제공한다.
+- 이미지 업로드 UI는 비활성화하거나 이미지 없이 생성하도록 유도한다.
+- `Z006` 응답은 자동 재시도하지 않는다.
+
+storage가 활성화되면 같은 API에서 이미지 포함 요청이 기존 업로드 흐름으로 처리된다.

--- a/sql/schema/00_baseline.sql
+++ b/sql/schema/00_baseline.sql
@@ -160,7 +160,7 @@ CREATE TABLE IF NOT EXISTS post (
     deleted_at timestamp(6),
     updated_at timestamp(6),
     like_cnt integer NOT NULL,
-    post_thumbnail_url varchar(255) NOT NULL,
+    post_thumbnail_url varchar(255),
     contents varchar(350) NOT NULL,
     view_cnt integer NOT NULL,
     CONSTRAINT fk_post_daily_jogak FOREIGN KEY (daily_jogak_id) REFERENCES daily_jogak (daily_jogak_id),

--- a/src/main/java/com/mogak/spring/domain/post/Post.java
+++ b/src/main/java/com/mogak/spring/domain/post/Post.java
@@ -33,7 +33,7 @@ public class Post extends SoftDeletableEntity {
     @Builder.Default
     @OneToMany(mappedBy = "post")
     private List<PostImg> postImgs = new ArrayList<>();
-    @Column(nullable = false)
+    @Column
     private String postThumbnailUrl;
     @Column(nullable = false)
     private int viewCnt;

--- a/src/main/java/com/mogak/spring/service/PostServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/PostServiceImpl.java
@@ -61,7 +61,6 @@ public class PostServiceImpl implements PostService {
     @Override
     public void validateCreateAccess(Long userId, LocalDate targetDate, String contents, List<MultipartFile> multipartFile, Long jogakId) {
         validateContents(contents);
-        validateSourceImages(multipartFile);
         DailyJogak dailyJogak = getOwnedDailyJogak(userId, jogakId, targetDate);
         validateTargetDate(dailyJogak.getJogak(), dailyJogak.getTargetDate());
         if (postRepository.existsByDailyJogakIdAndDeletedAtIsNull(dailyJogak.getId())) {
@@ -74,7 +73,6 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post create(Long userId, LocalDate targetDate, String contents, List<UploadedPostImageResult> uploadedImages, Long jogakId) {
         validateContents(contents);
-        validateCreatedImages(uploadedImages);
         DailyJogak dailyJogak = getOwnedDailyJogak(userId, jogakId, targetDate);
         validateTargetDate(dailyJogak.getJogak(), targetDate);
         if (postRepository.existsByDailyJogakIdAndDeletedAtIsNull(dailyJogak.getId())) {
@@ -83,7 +81,7 @@ public class PostServiceImpl implements PostService {
         User user = userRepository.findActiveById(userId)
                 .orElseThrow(() -> new UserException(ErrorCode.NOT_EXIST_USER));
         Post post = Post.create(dailyJogak, user, contents);
-        for (UploadedPostImageResult uploadedImage : uploadedImages) {
+        for (UploadedPostImageResult uploadedImage : normalizeUploadedImages(uploadedImages)) {
             PostImg postImg = PostImg.create(post, uploadedImage.imgName(), uploadedImage.imgUrl());
             //썸네일이미지인지 체크 필요
             if (uploadedImage.isThumbnail()) {
@@ -268,7 +266,7 @@ public class PostServiceImpl implements PostService {
         List<PostImg> postImgList = postImgRepository.findAllByPost(post);
         List<String> imgUrls = new ArrayList<>();
         for (PostImg postImg : postImgList) {
-            if (!thumbnailUrl.equals(postImg.getImgUrl())) {
+            if (!Objects.equals(thumbnailUrl, postImg.getImgUrl())) {
                 imgUrls.add(postImg.getImgUrl());
             }
         }
@@ -333,16 +331,11 @@ public class PostServiceImpl implements PostService {
         }
     }
 
-    private void validateSourceImages(List<MultipartFile> multipartFile) {
-        if (multipartFile == null || multipartFile.stream().allMatch(MultipartFile::isEmpty)) {
-            throw new PostException(ErrorCode.NOT_HAVE_IMAGE);
+    private List<UploadedPostImageResult> normalizeUploadedImages(List<UploadedPostImageResult> uploadedImages) {
+        if (uploadedImages == null) {
+            return List.of();
         }
-    }
-
-    private void validateCreatedImages(List<UploadedPostImageResult> uploadedImages) {
-        if (uploadedImages == null || uploadedImages.isEmpty()) {
-            throw new PostException(ErrorCode.NOT_HAVE_IMAGE);
-        }
+        return uploadedImages;
     }
 
     private void validateOwner(Long ownerUserId, Long userId) {

--- a/src/main/java/com/mogak/spring/web/controller/PostController.java
+++ b/src/main/java/com/mogak/spring/web/controller/PostController.java
@@ -56,9 +56,12 @@ public class PostController {
     public ResponseEntity<BaseResponse<CreatePostResponse>> createPost(@PathVariable Long jogakId,
                                                                   @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                   @Valid @RequestPart CreatePostRequest request,
-                                                                  @RequestPart(required = true) List<MultipartFile> multipartFile) {
-        postService.validateCreateAccess(authenticatedUser.getUserId(), request.targetDate(), request.contents(), multipartFile, jogakId);
-        List<UploadedPostImageResult> uploadedImages = storageService.uploadImg(multipartFile, DIR_NAME);
+                                                                  @RequestPart(required = false) List<MultipartFile> multipartFile) {
+        List<MultipartFile> postImages = normalizePostImages(multipartFile);
+        postService.validateCreateAccess(authenticatedUser.getUserId(), request.targetDate(), request.contents(), postImages, jogakId);
+        List<UploadedPostImageResult> uploadedImages = postImages.isEmpty()
+                ? List.of()
+                : storageService.uploadImg(postImages, DIR_NAME);
         Post post;
         try {
             post = postService.create(authenticatedUser.getUserId(), request.targetDate(), request.contents(), uploadedImages, jogakId);
@@ -73,6 +76,15 @@ public class PostController {
                 .map(PostImg::getImgUrl)
                 .toList();
         return ResponseEntity.ok(new BaseResponse<>(CreatePostResponse.from(post, imgUrls)));
+    }
+
+    private List<MultipartFile> normalizePostImages(List<MultipartFile> multipartFile) {
+        if (multipartFile == null) {
+            return List.of();
+        }
+        return multipartFile.stream()
+                .filter(file -> !file.isEmpty())
+                .toList();
     }
 
     //read-전체 조회

--- a/src/test/java/com/mogak/spring/service/PostServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/PostServiceImplTest.java
@@ -120,6 +120,26 @@ class PostServiceImplTest {
     }
 
     @Test
+    @DisplayName("게시글 생성 preflight는 null 또는 빈 이미지 목록을 허용한다")
+    void validateCreateAccessAcceptsNullAndEmptyImages() {
+        User owner = user(1L, "owner@test.com");
+        LocalDate targetDate = LocalDate.now();
+        var jogak = TestFixtureFactory.jogak(20L, mogak(10L, owner), "jogak", false, java.time.LocalDate.now(), null, 0);
+        var dailyJogak = TestFixtureFactory.dailyJogak(30L, jogak, targetDate, DailyJogakStatus.SUCCESS);
+
+        when(dailyJogakRepository.findActiveByJogakIdAndTargetDateWithJogakGraph(20L, targetDate))
+                .thenReturn(Optional.of(dailyJogak));
+        when(postRepository.existsByDailyJogakIdAndDeletedAtIsNull(30L)).thenReturn(false);
+
+        Throwable nullImages = catchThrowable(() -> postService.validateCreateAccess(1L, targetDate, "content", null, 20L));
+        Throwable emptyImages = catchThrowable(() -> postService.validateCreateAccess(1L, targetDate, "content", List.of(emptyImage()), 20L));
+
+        assertThat(nullImages).isNull();
+        assertThat(emptyImages).isNull();
+        verify(postRepository, times(2)).existsByDailyJogakIdAndDeletedAtIsNull(30L);
+    }
+
+    @Test
     @DisplayName("게시글 생성에 성공하면 이미지와 게시글을 저장한다")
     void createSavesPostAfterValidationWithImages() {
         User writer = user(1L, "writer@test.com");
@@ -145,6 +165,30 @@ class PostServiceImplTest {
         assertThat(result.getPostImgs()).hasSize(1);
         assertThat(result.getPostThumbnailUrl()).isEqualTo("https://example.com/thumb.png");
         verify(postImgRepository, times(2)).save(any(PostImg.class));
+        verify(postRepository).saveAndFlush(any(Post.class));
+    }
+
+    @Test
+    @DisplayName("게시글 생성은 업로드 이미지가 비어 있으면 이미지 없이 게시글만 저장한다")
+    void createWithEmptyUploadedImagesSavesPostWithoutImagesAndThumbnail() {
+        User writer = user(1L, "writer@test.com");
+        LocalDate targetDate = LocalDate.now();
+        Mogak mogak = mogak(10L, writer);
+        var jogak = TestFixtureFactory.jogak(20L, mogak, "jogak", false, java.time.LocalDate.now(), null, 0);
+        var dailyJogak = TestFixtureFactory.dailyJogak(30L, jogak, targetDate, DailyJogakStatus.SUCCESS);
+
+        when(dailyJogakRepository.findActiveByJogakIdAndTargetDateWithJogakGraph(20L, targetDate))
+                .thenReturn(Optional.of(dailyJogak));
+        when(userRepository.findActiveById(1L)).thenReturn(Optional.of(writer));
+        when(postRepository.saveAndFlush(any(Post.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Post result = postService.create(1L, targetDate, "content", List.of(), 20L);
+
+        assertThat(result.getDailyJogak()).isSameAs(dailyJogak);
+        assertThat(result.getUser()).isSameAs(writer);
+        assertThat(result.getPostImgs()).isEmpty();
+        assertThat(result.getPostThumbnailUrl()).isNull();
+        verify(postImgRepository, never()).save(any(PostImg.class));
         verify(postRepository).saveAndFlush(any(Post.class));
     }
 
@@ -241,6 +285,38 @@ class PostServiceImplTest {
 
         assertThat(result).containsExactly(20L);
         verify(postCommentRepository).findActiveAllByPost(post);
+    }
+
+    @Test
+    @DisplayName("썸네일이 없는 게시글의 상세 이미지는 모든 이미지를 반환한다")
+    void findNotThumbnailImgReturnsAllImagesWhenThumbnailIsNull() {
+        User owner = user(1L, "owner@test.com");
+        Post post = Post.builder()
+                .id(10L)
+                .dailyJogak(post(10L, owner).getDailyJogak())
+                .user(owner)
+                .contents("content")
+                .postThumbnailUrl(null)
+                .viewCnt(0)
+                .build();
+        PostImg first = PostImg.builder()
+                .id(20L)
+                .post(post)
+                .imgName("first.png")
+                .imgUrl("https://example.com/first.png")
+                .build();
+        PostImg second = PostImg.builder()
+                .id(21L)
+                .post(post)
+                .imgName("second.png")
+                .imgUrl("https://example.com/second.png")
+                .build();
+
+        when(postImgRepository.findAllByPost(post)).thenReturn(List.of(first, second));
+
+        List<String> result = postService.findNotThumbnailImg(post);
+
+        assertThat(result).containsExactly("https://example.com/first.png", "https://example.com/second.png");
     }
 
     @Test
@@ -392,6 +468,15 @@ class PostServiceImplTest {
                 fileName,
                 "image/png",
                 "png".getBytes()
+        );
+    }
+
+    private MultipartFile emptyImage() {
+        return new org.springframework.mock.web.MockMultipartFile(
+                "multipartFile",
+                "",
+                "application/octet-stream",
+                new byte[0]
         );
     }
 }

--- a/src/test/java/com/mogak/spring/web/controller/PostControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/PostControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mogak.spring.domain.mogak.Mogak;
 import com.mogak.spring.domain.post.Post;
 import com.mogak.spring.exception.AuthException;
+import com.mogak.spring.exception.BaseException;
 import com.mogak.spring.exception.GlobalExceptionHandler;
 import com.mogak.spring.exception.PostException;
 import com.mogak.spring.global.ErrorCode;
@@ -126,6 +127,111 @@ class PostControllerTest {
         inOrder.verify(postService).validateCreateAccess(eq(7L), any(LocalDate.class), any(String.class), anyList(), eq(1L));
         inOrder.verify(storageService).uploadImg(any(), any());
         inOrder.verify(postService).create(eq(7L), any(LocalDate.class), any(String.class), eq(uploadedImages), eq(1L));
+    }
+
+    @Test
+    @DisplayName("게시글 생성은 이미지 part가 없어도 storage 업로드 없이 생성한다")
+    void createPostWithoutMultipartFileCreatesWithoutStorageUpload() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
+        CreatePostRequest request = createRequest("content");
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+        );
+        Post post = createPost(1L, 7L, 1L, "content", null);
+
+        when(postService.create(eq(7L), any(LocalDate.class), eq("content"), eq(List.of()), eq(1L))).thenReturn(post);
+
+        mockMvc.perform(multipart("/api/jogaks/{jogakId}/posts", 1L)
+                        .file(requestPart)
+                        .with(mockRequest -> {
+                            mockRequest.setMethod("POST");
+                            return mockRequest;
+                        }))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.id").value(1))
+                .andExpect(jsonPath("$.result.imgUrls").isArray())
+                .andExpect(jsonPath("$.result.imgUrls").isEmpty());
+
+        verify(postService).validateCreateAccess(eq(7L), any(LocalDate.class), eq("content"), eq(List.of()), eq(1L));
+        verify(storageService, never()).uploadImg(any(), any());
+        verify(postService).create(eq(7L), any(LocalDate.class), eq("content"), eq(List.of()), eq(1L));
+    }
+
+    @Test
+    @DisplayName("게시글 생성은 빈 이미지 part를 이미지 없음으로 처리한다")
+    void createPostWithEmptyMultipartFileTreatsImageAsMissing() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
+        CreatePostRequest request = createRequest("content");
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+        );
+        MockMultipartFile emptyImage = new MockMultipartFile(
+                "multipartFile",
+                "",
+                MediaType.APPLICATION_OCTET_STREAM_VALUE,
+                new byte[0]
+        );
+        Post post = createPost(1L, 7L, 1L, "content", null);
+
+        when(postService.create(eq(7L), any(LocalDate.class), eq("content"), eq(List.of()), eq(1L))).thenReturn(post);
+
+        mockMvc.perform(multipart("/api/jogaks/{jogakId}/posts", 1L)
+                        .file(requestPart)
+                        .file(emptyImage)
+                        .with(mockRequest -> {
+                            mockRequest.setMethod("POST");
+                            return mockRequest;
+                        }))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.id").value(1))
+                .andExpect(jsonPath("$.result.imgUrls").isArray())
+                .andExpect(jsonPath("$.result.imgUrls").isEmpty());
+
+        verify(postService).validateCreateAccess(eq(7L), any(LocalDate.class), eq("content"), eq(List.of()), eq(1L));
+        verify(storageService, never()).uploadImg(any(), any());
+        verify(postService).create(eq(7L), any(LocalDate.class), eq("content"), eq(List.of()), eq(1L));
+    }
+
+    @Test
+    @DisplayName("게시글 생성은 실제 이미지 업로드 중 storage 비활성화를 503으로 전파한다")
+    void createPostWithActualImagePropagatesStorageDisabled() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
+        CreatePostRequest request = createRequest("content");
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+        );
+        MockMultipartFile image = new MockMultipartFile(
+                "multipartFile",
+                "post.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "png".getBytes()
+        );
+
+        when(storageService.uploadImg(any(), eq("img"))).thenThrow(new BaseException(ErrorCode.STORAGE_DISABLED));
+
+        mockMvc.perform(multipart("/api/jogaks/{jogakId}/posts", 1L)
+                        .file(requestPart)
+                        .file(image)
+                        .with(mockRequest -> {
+                            mockRequest.setMethod("POST");
+                            return mockRequest;
+                        }))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.code").value("Z006"));
+
+        verify(storageService).uploadImg(any(), eq("img"));
+        verify(postService, never()).create(any(), any(), any(), anyList(), any());
+        verify(storageCleanupService, never()).deleteUploadedImagesBestEffort(anyList(), any());
     }
 
     @Test
@@ -323,6 +429,30 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.result.numberOfElements").value(1))
                 .andExpect(jsonPath("$.result.first").value(true))
                 .andExpect(jsonPath("$.result.last").value(false));
+    }
+
+    @Test
+    @DisplayName("모각별 게시글 조회는 이미지 없는 게시글의 thumbnailUrl을 null로 반환한다")
+    void getPostListReturnsNullThumbnailUrlWhenPostHasNoImage() throws Exception {
+        SecurityContextTestHelper.setAuthentication(7L, "writer@test.com", "ROLE_USER");
+        PostSummaryResult post = new PostSummaryResult(
+                11L,
+                1L,
+                2L,
+                3L,
+                LocalDate.of(2026, 4, 21),
+                "오늘 회고",
+                null,
+                4
+        );
+        Slice<PostSummaryResult> posts = new SliceImpl<>(List.of(post), PageRequest.of(0, 10), false);
+        when(postService.getAllPosts(7L, 0, 1L, 10)).thenReturn(posts);
+
+        mockMvc.perform(get("/api/mogaks/{mogakId}/posts", 1L)
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.content[0].thumbnailUrl").isEmpty());
     }
 
     @Test

--- a/src/test/java/com/mogak/spring/web/dto/postdto/PostResponseContractTest.java
+++ b/src/test/java/com/mogak/spring/web/dto/postdto/PostResponseContractTest.java
@@ -34,4 +34,27 @@ class PostResponseContractTest {
 
         assertThat(result.commentId()).containsExactly(7L);
     }
+
+    @Test
+    @DisplayName("게시글 생성 응답은 이미지 없는 게시글의 빈 이미지 URL 목록을 유지한다")
+    void createPostResponseKeepsEmptyImageUrlsWhenPostHasNoImage() {
+        User user = TestFixtureFactory.user(1L, "user@test.com", "tester", null, null);
+        var modarat = TestFixtureFactory.modarat(2L, user, "모다라트", "#000000");
+        var mogak = TestFixtureFactory.mogak(3L, user, modarat, TestFixtureFactory.category(1, "자격증"), "모각", "#111111");
+        var jogak = TestFixtureFactory.jogak(4L, mogak, "조각", false, LocalDate.now(), null, 0);
+        var dailyJogak = TestFixtureFactory.dailyJogak(5L, jogak, false);
+        Post post = Post.builder()
+                .id(6L)
+                .dailyJogak(dailyJogak)
+                .user(user)
+                .contents("content")
+                .postThumbnailUrl(null)
+                .viewCnt(0)
+                .build();
+
+        var result = CreatePostResponse.from(post, List.of());
+
+        assertThat(result.imgUrls()).isEmpty();
+        assertThat(result.contents()).isEqualTo("content");
+    }
 }


### PR DESCRIPTION
## Summary
- 회고 생성 API에서 이미지 파트를 선택값으로 허용
- 이미지 없는 회고의 `imgUrls: []`, `thumbnailUrl: null` 계약 고정
- storage disabled 상태에서 실제 이미지 포함 요청은 기존 `503 Z006` 유지
- 회고 생성 이미지 계약 문서 추가

## Tests
- `sh gradlew test --rerun-tasks --no-daemon`

Closes #165