### PR TITLE
API URL 계층 prefix 정리

### DIFF
--- a/src/main/java/com/mogak/spring/web/controller/JogakController.java
+++ b/src/main/java/com/mogak/spring/web/controller/JogakController.java
@@ -49,7 +49,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 @Tag(name = "조각 API", description = "조각 API 명세서")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/modarats/mogaks/jogaks")
+@RequestMapping("/api")
 public class JogakController {
     private final JogakService jogakService;
 
@@ -62,7 +62,7 @@ public class JogakController {
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 모각",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
-    @PostMapping("")
+    @PostMapping("/jogaks")
     public ResponseEntity<BaseResponse<CreateJogakResponse>> create(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                  @Valid @RequestBody CreateJogakRequest createJogakRequest) {
         CreateJogakResult result = jogakService.createJogak(
@@ -86,7 +86,7 @@ public class JogakController {
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 유저",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
-    @GetMapping("/{jogakId}/detail")
+    @GetMapping("/jogaks/{jogakId}")
     public ResponseEntity<BaseResponse<JogakDetailResponse>> getJogakDetail(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                          @PathVariable Long jogakId) {
         return ResponseEntity.ok(new BaseResponse<>(toJogakDetailResponse(jogakService.getJogakDetail(authenticatedUser.getUserId(), jogakId))));
@@ -100,7 +100,7 @@ public class JogakController {
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 유저",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
-    @GetMapping("/daily")
+    @GetMapping("/jogaks/daily")
     public ResponseEntity<BaseResponse<OneTimeJogakListResponse>> getDailyJogaks(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
             @Parameter(description = "조회를 원하는 날짜를 입력해주시면 됩니다. format: YYYY-MM-DD", example = "2024-02-15")
             @RequestParam("date") @DateTimeFormat(iso = ISO.DATE) LocalDate date) {
@@ -114,7 +114,7 @@ public class JogakController {
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 유저",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
-    @GetMapping
+    @GetMapping("/jogaks")
     public ResponseEntity<BaseResponse<DailyJogakListResponse>> getDayJogaks(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
             @Parameter(description = "조회를 원하는 날짜를 입력해주시면 됩니다. format: YYYY-MM-DD", example = "2024-02-14")
             @RequestParam("date") @DateTimeFormat(iso = ISO.DATE) LocalDate date) {
@@ -128,7 +128,7 @@ public class JogakController {
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 유저",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
-    @GetMapping("/routines")
+    @GetMapping("/jogaks/routines")
     public ResponseEntity<BaseResponse<List<RoutineJogakResponse>>> getRoutineJogaks(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
             @Parameter(description = "조회를 원하는 첫 날짜를 입력. format: YYYY-MM-DD", example = "2024-02-14")
             @RequestParam("startDay") @DateTimeFormat(iso = ISO.DATE) LocalDate startDay,
@@ -149,7 +149,7 @@ public class JogakController {
                     @ApiResponse(responseCode = "409", description = "이미 시작한 조각",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
-    @PostMapping("{jogakId}/start")
+    @PostMapping("/jogaks/{jogakId}/start")
     public ResponseEntity<BaseResponse<JogakDailyResponse>> startJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                         @PathVariable Long jogakId) {
         return ResponseEntity.ok(new BaseResponse<>(toJogakDailyResponse(jogakService.startJogak(authenticatedUser.getUserId(), jogakId))));
@@ -167,7 +167,7 @@ public class JogakController {
                     @ApiResponse(responseCode = "409", description = "이미 종료한 조각",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
-    @PutMapping("{dailyJogakId}/success")
+    @PutMapping("/daily-jogaks/{dailyJogakId}/success")
     public ResponseEntity<BaseResponse<JogakDailyResponse>> successJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                            @PathVariable Long dailyJogakId) {
         return ResponseEntity.ok(new BaseResponse<>(toJogakDailyResponse(jogakService.successJogak(authenticatedUser.getUserId(), dailyJogakId))));
@@ -185,7 +185,7 @@ public class JogakController {
                     @ApiResponse(responseCode = "409", description = "이미 종료한 조각",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
-    @PutMapping("{dailyJogakId}/fail")
+    @PutMapping("/daily-jogaks/{dailyJogakId}/fail")
     public ResponseEntity<BaseResponse<JogakDailyResponse>> failJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                         @PathVariable Long dailyJogakId) {
         return ResponseEntity.ok(new BaseResponse<>(toJogakDailyResponse(jogakService.failJogak(authenticatedUser.getUserId(), dailyJogakId))));
@@ -200,7 +200,7 @@ public class JogakController {
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 조각, 존재하지 않는 카테고리",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
-    @PutMapping("/{jogakId}")
+    @PutMapping("/jogaks/{jogakId}")
     public ResponseEntity<BaseResponse<CreateJogakResponse>> updateJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                @PathVariable Long jogakId,
                                                                @Valid @RequestBody UpdateJogakRequest updateJogakRequest) {
@@ -225,7 +225,7 @@ public class JogakController {
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 조각",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
-    @DeleteMapping("/{jogakId}")
+    @DeleteMapping("/jogaks/{jogakId}")
     public ResponseEntity<BaseResponse<ErrorCode>> deleteJogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                @PathVariable Long jogakId) {
         jogakService.deleteJogak(authenticatedUser.getUserId(), jogakId);

--- a/src/main/java/com/mogak/spring/web/controller/MogakController.java
+++ b/src/main/java/com/mogak/spring/web/controller/MogakController.java
@@ -36,7 +36,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 @Tag(name = "모각 API", description = "모각 API 명세서")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/modarats")
+@RequestMapping("/api")
 public class MogakController {
     private final MogakService mogakService;
 
@@ -82,12 +82,13 @@ public class MogakController {
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 모각, 존재하지 않는 카테고리",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    @PutMapping("/mogaks")
+    @PutMapping("/mogaks/{mogakId}")
     public ResponseEntity<BaseResponse<MogakResponse>> updateMogak(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+                                                                                  @PathVariable Long mogakId,
                                                                                   @Valid @RequestBody UpdateMogakRequest request) {
         MogakResult result = mogakService.updateMogak(
                 authenticatedUser.getUserId(),
-                request.mogakId(),
+                mogakId,
                 request.title(),
                 request.bigCategory(),
                 request.smallCategory(),
@@ -103,7 +104,7 @@ public class MogakController {
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자",
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
-    @GetMapping("/{modaratId}/mogaks")
+    @GetMapping("/modarats/{modaratId}/mogaks")
     public ResponseEntity<BaseResponse<MogakListResponse>> getMogakList(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
                                                                                        @PathVariable Long modaratId) {
         return ResponseEntity.ok(new BaseResponse<>(toMogakListResponse(mogakService.getMogakList(authenticatedUser.getUserId(), modaratId))));

--- a/src/main/java/com/mogak/spring/web/dto/mogakdto/UpdateMogakRequest.java
+++ b/src/main/java/com/mogak/spring/web/dto/mogakdto/UpdateMogakRequest.java
@@ -4,8 +4,6 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record UpdateMogakRequest(
-        @NotNull
-        Long mogakId,
         @Size(min = 1, max = 100)
         String title,
         @NotNull

--- a/src/test/java/com/mogak/spring/web/controller/JogakControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/JogakControllerTest.java
@@ -7,13 +7,16 @@ import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.jwt.JwtTokenProvider;
 import com.mogak.spring.service.JogakService;
 import com.mogak.spring.service.command.CreateJogakCommand;
+import com.mogak.spring.service.command.UpdateJogakCommand;
 import com.mogak.spring.service.result.CreateJogakResult;
 import com.mogak.spring.service.result.DailyJogakListResult;
 import com.mogak.spring.service.result.DailyJogakResult;
 import com.mogak.spring.service.result.JogakDailyResult;
+import com.mogak.spring.service.result.JogakDetailResult;
 import com.mogak.spring.service.result.OneTimeJogakListResult;
 import com.mogak.spring.service.result.OneTimeJogakResult;
 import com.mogak.spring.service.result.RoutineJogakResult;
+import com.mogak.spring.web.dto.jogakdto.UpdateJogakRequest;
 import com.mogak.spring.support.SecurityContextTestHelper;
 
 import org.junit.jupiter.api.AfterEach;
@@ -37,6 +40,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -88,7 +92,7 @@ class JogakControllerTest {
                 )
         );
 
-        mockMvc.perform(post("/api/modarats/mogaks/jogaks")
+        mockMvc.perform(post("/api/jogaks")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"mogakId\":1,\"title\":\"문제풀이\",\"isRoutine\":false,\"today\":\"2026-03-26\"}"))
                 .andExpect(status().isCreated())
@@ -104,7 +108,7 @@ class JogakControllerTest {
     @Test
     @DisplayName("조각 생성 요청이 유효하지 않으면 에러 응답 계약을 반환한다")
     void createJogakValidationErrorContract() throws Exception {
-        mockMvc.perform(post("/api/modarats/mogaks/jogaks")
+        mockMvc.perform(post("/api/jogaks")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"mogakId\":1,\"title\":\"문제풀이\",\"isRoutine\":false}"))
                 .andExpect(status().isBadRequest())
@@ -135,7 +139,7 @@ class JogakControllerTest {
                 )
         );
 
-        mockMvc.perform(get("/api/modarats/mogaks/jogaks/daily")
+        mockMvc.perform(get("/api/jogaks/daily")
                         .param("date", "2026-03-26"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -154,7 +158,7 @@ class JogakControllerTest {
                 new RoutineJogakResult(-1L, LocalDate.of(2026, 3, 27), false, "루틴 조각")
         ));
 
-        mockMvc.perform(get("/api/modarats/mogaks/jogaks/routines")
+        mockMvc.perform(get("/api/jogaks/routines")
                         .param("startDay", "2026-03-26")
                         .param("endDay", "2026-03-30"))
                 .andExpect(status().isOk())
@@ -185,7 +189,7 @@ class JogakControllerTest {
                 )
         );
 
-        mockMvc.perform(get("/api/modarats/mogaks/jogaks")
+        mockMvc.perform(get("/api/jogaks")
                         .param("date", "2026-03-26"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -195,6 +199,35 @@ class JogakControllerTest {
                 .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
                 .andExpect(jsonPath("$.result.size").value(1))
                 .andExpect(jsonPath("$.result.dailyJogaks[0].title").value("루틴 조각"));
+    }
+
+    @Test
+    @DisplayName("조각 단일 조회 요청이 성공하면 조회 응답 계약을 반환한다")
+    void getJogakContract() throws Exception {
+        when(jogakService.getJogakDetail(1L, 1L)).thenReturn(
+                new JogakDetailResult(
+                        1L,
+                        "정보처리기사",
+                        "자격증",
+                        "문제풀이",
+                        false,
+                        List.of("MONDAY"),
+                        "#112233",
+                        2,
+                        LocalDate.of(2026, 3, 1),
+                        LocalDate.of(2026, 3, 31)
+                )
+        );
+
+        mockMvc.perform(get("/api/jogaks/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.time").exists())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.code").value("success"))
+                .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
+                .andExpect(jsonPath("$.result.jogakId").value(1L))
+                .andExpect(jsonPath("$.result.title").value("문제풀이"));
     }
 
     @Test
@@ -214,7 +247,7 @@ class JogakControllerTest {
                 )
         );
 
-        mockMvc.perform(post("/api/modarats/mogaks/jogaks/1/start"))
+        mockMvc.perform(post("/api/jogaks/1/start"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.time").exists())
@@ -230,13 +263,60 @@ class JogakControllerTest {
     void startJogakAlreadyStartedErrorContract() throws Exception {
         when(jogakService.startJogak(1L, 1L)).thenThrow(new JogakException(ErrorCode.ALREADY_START_JOGAK));
 
-        mockMvc.perform(post("/api/modarats/mogaks/jogaks/1/start"))
+        mockMvc.perform(post("/api/jogaks/1/start"))
                 .andExpect(status().isConflict())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.time").exists())
                 .andExpect(jsonPath("$.status").value("CONFLICT"))
                 .andExpect(jsonPath("$.code").value("J002"))
                 .andExpect(jsonPath("$.message").value("이미 시작한 조각입니다"));
+    }
+
+    @Test
+    @DisplayName("조각 수정 요청이 성공하면 수정 응답 계약을 반환한다")
+    void updateJogakContract() throws Exception {
+        when(jogakService.updateJogak(eq(1L), eq(1L), any(UpdateJogakCommand.class))).thenReturn(
+                new CreateJogakResult(
+                        1L,
+                        "정보처리기사",
+                        "자격증",
+                        "문제풀이(수정)",
+                        false,
+                        List.of("MONDAY"),
+                        0,
+                        LocalDate.of(2026, 3, 1),
+                        LocalDate.of(2026, 4, 30)
+                )
+        );
+
+        mockMvc.perform(put("/api/jogaks/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new UpdateJogakRequest(
+                                "문제풀이(수정)",
+                                false,
+                                List.of("MONDAY"),
+                                LocalDate.of(2026, 4, 30)
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.time").exists())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.code").value("success"))
+                .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
+                .andExpect(jsonPath("$.result.title").value("문제풀이(수정)"));
+    }
+
+    @Test
+    @DisplayName("조각 삭제 요청이 성공하면 성공 응답 계약을 반환한다")
+    void deleteJogakContract() throws Exception {
+        mockMvc.perform(delete("/api/jogaks/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.time").exists())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.code").value("success"))
+                .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
+                .andExpect(jsonPath("$.result").doesNotExist());
     }
 
     @Test
@@ -256,7 +336,7 @@ class JogakControllerTest {
                 )
         );
 
-        mockMvc.perform(put("/api/modarats/mogaks/jogaks/10/success"))
+        mockMvc.perform(put("/api/daily-jogaks/10/success"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.time").exists())
@@ -268,11 +348,39 @@ class JogakControllerTest {
     }
 
     @Test
+    @DisplayName("조각 실패 요청이 성공하면 응답 계약을 반환한다")
+    void failJogakContract() throws Exception {
+        when(jogakService.failJogak(1L, 10L)).thenReturn(
+                new JogakDailyResult(
+                        1L,
+                        10L,
+                        "문제풀이",
+                        "정보처리기사",
+                        "자격증",
+                        false,
+                        null,
+                        false,
+                        0
+                )
+        );
+
+        mockMvc.perform(put("/api/daily-jogaks/10/fail"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.time").exists())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.code").value("success"))
+                .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
+                .andExpect(jsonPath("$.result.dailyJogakId").value(10L))
+                .andExpect(jsonPath("$.result.isAchievement").value(false));
+    }
+
+    @Test
     @DisplayName("이미 종료한 조각의 성공을 요청하면 에러 응답 계약을 반환한다")
     void successJogakAlreadyEndedErrorContract() throws Exception {
         when(jogakService.successJogak(1L, 10L)).thenThrow(new JogakException(ErrorCode.ALREADY_END_JOGAK));
 
-        mockMvc.perform(put("/api/modarats/mogaks/jogaks/10/success"))
+        mockMvc.perform(put("/api/daily-jogaks/10/success"))
                 .andExpect(status().isConflict())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.time").exists())
@@ -286,12 +394,21 @@ class JogakControllerTest {
     void successJogakNotFoundErrorContract() throws Exception {
         when(jogakService.successJogak(1L, 999L)).thenThrow(new JogakException(ErrorCode.NOT_EXIST_JOGAK));
 
-        mockMvc.perform(put("/api/modarats/mogaks/jogaks/999/success"))
+        mockMvc.perform(put("/api/daily-jogaks/999/success"))
                 .andExpect(status().isNotFound())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.time").exists())
                 .andExpect(jsonPath("$.status").value("NOT_FOUND"))
                 .andExpect(jsonPath("$.code").value("J005"))
                 .andExpect(jsonPath("$.message").value("존재하지 않는 조각입니다"));
+    }
+
+    @Test
+    @DisplayName("구버전 조각 생성 라우트는 더 이상 노출되지 않는다")
+    void legacyCreateJogakRouteIsNotExposed() throws Exception {
+        mockMvc.perform(post("/api/modarats/mogaks/jogaks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/mogak/spring/web/controller/MogakControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/MogakControllerTest.java
@@ -12,7 +12,6 @@ import com.mogak.spring.service.result.MogakListResult;
 import com.mogak.spring.service.result.MogakResult;
 import com.mogak.spring.support.SecurityContextTestHelper;
 import com.mogak.spring.web.dto.mogakdto.CreateMogakRequest;
-import com.mogak.spring.web.dto.mogakdto.UpdateMogakRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -84,7 +83,7 @@ class MogakControllerTest {
                 )
         );
 
-        mockMvc.perform(post("/api/modarats/mogaks")
+        mockMvc.perform(post("/api/mogaks")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new CreateMogakRequest(
                                 10L,
@@ -109,7 +108,7 @@ class MogakControllerTest {
     @Test
     @DisplayName("모각 생성 요청이 유효하지 않으면 에러 응답 계약을 반환한다")
     void createMogakValidationErrorContract() throws Exception {
-        mockMvc.perform(post("/api/modarats/mogaks")
+        mockMvc.perform(post("/api/mogaks")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"title\":\"정보처리기사\"}"))
                 .andExpect(status().isBadRequest())
@@ -167,7 +166,7 @@ class MogakControllerTest {
                 )
         ));
 
-        mockMvc.perform(get("/api/modarats/mogaks/1/jogaks")
+        mockMvc.perform(get("/api/mogaks/1/jogaks")
                         .param("date", "2026-03-26"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -184,7 +183,7 @@ class MogakControllerTest {
     @Test
     @DisplayName("모각 삭제 요청이 성공하면 성공 응답 계약을 반환한다")
     void deleteMogakContract() throws Exception {
-        mockMvc.perform(delete("/api/modarats/mogaks/1"))
+        mockMvc.perform(delete("/api/mogaks/1"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.time").exists())
@@ -209,15 +208,9 @@ class MogakControllerTest {
                 )
         );
 
-        mockMvc.perform(put("/api/modarats/mogaks")
+        mockMvc.perform(put("/api/mogaks/1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new UpdateMogakRequest(
-                                1L,
-                                "수정된 모각",
-                                "자격증",
-                                "필기",
-                                "#112233"
-                        ))))
+                        .content("{\"title\":\"수정된 모각\",\"bigCategory\":\"자격증\",\"smallCategory\":\"필기\",\"color\":\"#112233\"}"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.result.title").value("수정된 모각"));
 
@@ -230,12 +223,21 @@ class MogakControllerTest {
         doThrow(new MogakException(ErrorCode.NOT_EXIST_MOGAK))
                 .when(mogakService).deleteMogak(1L, 99L);
 
-        mockMvc.perform(delete("/api/modarats/mogaks/99"))
+        mockMvc.perform(delete("/api/mogaks/99"))
                 .andExpect(status().isNotFound())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.time").exists())
                 .andExpect(jsonPath("$.status").value("NOT_FOUND"))
                 .andExpect(jsonPath("$.code").value("M004"))
                 .andExpect(jsonPath("$.message").value("존재하지 않는 모각입니다"));
+    }
+
+    @Test
+    @DisplayName("구버전 모각 생성 라우트는 더 이상 노출되지 않는다")
+    void legacyCreateMogakRouteIsNotExposed() throws Exception {
+        mockMvc.perform(post("/api/modarats/mogaks")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"modaratId\":10,\"title\":\"정보처리기사\",\"bigCategory\":\"자격증\",\"smallCategory\":\"필기\",\"color\":\"#112233\"}"))
+                .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
## 해결하려던 문제 혹은 구현하려는 기능

- 일부 Jogak/Mogak API URL이 실제 검증에 쓰이지 않는 상위 자원명을 고정 prefix로 포함하고 있어 경로가 불필요하게 길었습니다.
- Jogak/Mogak API를 대표 리소스 기준 URL로 정리했습니다.
- 부모 ID를 실제 요청 경계에서 사용하는 `GET /api/modarats/{modaratId}/mogaks`는 유지했습니다.
- 수정 대상 식별자는 URL path variable로 단일화했습니다.
  - `UpdateMogakRequest`의 `mogakId` 제거
  - `PUT /api/mogaks/{mogakId}`의 path variable을 수정 대상 ID로 사용
  - path ID와 body ID가 서로 다른 경우의 모호성을 원천 제거

### 신규 경로

- `POST /api/jogaks`
- `GET /api/jogaks/{jogakId}`
- `GET /api/jogaks/daily`
- `GET /api/jogaks`
- `GET /api/jogaks/routines`
- `POST /api/jogaks/{jogakId}/start`
- `PUT /api/jogaks/{jogakId}`
- `DELETE /api/jogaks/{jogakId}`
- `PUT /api/daily-jogaks/{dailyJogakId}/success`
- `PUT /api/daily-jogaks/{dailyJogakId}/fail`
- `POST /api/mogaks`
- `PUT /api/mogaks/{mogakId}`
- `DELETE /api/mogaks/{mogakId}`
- `GET /api/mogaks/{mogakId}/jogaks`

### 요청 body 변경

모각 수정 API는 수정 대상 ID를 body가 아니라 path에서 받습니다.

기존:

```http
PUT /api/modarats/mogaks
Content-Type: application/json

{
  "mogakId": 1,
  "title": "수정된 모각",
  "bigCategory": "자격증",
  "smallCategory": "필기",
  "color": "#112233"
}
```

변경 후:

```http
PUT /api/mogaks/1
Content-Type: application/json

{
  "title": "수정된 모각",
  "bigCategory": "자격증",
  "smallCategory": "필기",
  "color": "#112233"
}
```

### 호환 정책

- 기존 `/api/modarats/mogaks...` 계열 경로는 호환 매핑 없이 제거했습니다.
- 클라이언트는 위 신규 경로와 요청 body 계약으로 전환해야 합니다.

## 테스트 시나리오

- Jogak/Mogak 컨트롤러 테스트를 신규 경로 기준으로 갱신했습니다.
- Jogak 상세/수정/삭제/fail 경로 계약 테스트를 추가했습니다.
- Mogak 수정 테스트에서 body에 `mogakId` 없이 path ID가 서비스로 전달되는지 검증했습니다.
- 대표 구 경로가 더 이상 노출되지 않는지 404 테스트를 추가했습니다.
- 검증 명령:
  - `sh gradlew test`
  - `git diff --check`

## 관련 이슈

- Closes #167