### PR TITLE
refactor(#138): Storage production 의존성 경계 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,6 @@ dependencies {
 		exclude group: 'org.bytedeco', module: 'javacv-platform'
 	}
 
-	// Test support used by production code
-	implementation 'org.springframework:spring-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-jackson-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'

--- a/src/main/java/com/mogak/spring/service/AwsS3Service.java
+++ b/src/main/java/com/mogak/spring/service/AwsS3Service.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,6 +27,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -70,9 +70,9 @@ public class AwsS3Service implements StorageService {
                 ));
                 if (multipartFile.get(0) == img) {
                     String thumbnailImgName = createThumbnailImgName(format, dirName);
-                    MultipartFile thumbnailImg = resizeImage(thumbnailImgName, format, img, 200, 200);
+                    ThumbnailImage thumbnailImg = resizeImage(format, img, 200, 200);
                     uploadedObjectNames.add(thumbnailImgName);
-                    uploadThumbnailToS3(thumbnailImgName, thumbnailImg, format);
+                    uploadThumbnailToS3(thumbnailImgName, thumbnailImg);
                     uploadedImages.add(new UploadedPostImageResult(
                             thumbnailImgName,
                             createObjectUrl(thumbnailImgName),
@@ -87,12 +87,9 @@ public class AwsS3Service implements StorageService {
         return uploadedImages;
     }
 
-    private void uploadThumbnailToS3(String thumbnailImgName, MultipartFile thumbnailImg, String format) {
-        try (InputStream inputThumbnailStream = thumbnailImg.getInputStream()) {
-            putObject(thumbnailImgName, thumbnailImg.getSize(), contentTypeForFormat(format), inputThumbnailStream);
-        } catch (IOException e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "s3 썸네일 업로드 실패했습니다");
-        }
+    private void uploadThumbnailToS3(String thumbnailImgName, ThumbnailImage thumbnailImg) {
+        ByteArrayInputStream inputThumbnailStream = new ByteArrayInputStream(thumbnailImg.bytes());
+        putObject(thumbnailImgName, thumbnailImg.size(), thumbnailImg.contentType(), inputThumbnailStream);
     }
 
     private void uploadImgToS3(String imgName, MultipartFile multipartFile, String format) {
@@ -116,7 +113,7 @@ public class AwsS3Service implements StorageService {
         );
     }
 
-    private MultipartFile resizeImage(String thumbnailImgName, String imgFormat, MultipartFile multipartFile, int width, int height) {
+    private ThumbnailImage resizeImage(String imgFormat, MultipartFile multipartFile, int width, int height) {
         try {
             BufferedImage image = ImageIO.read(multipartFile.getInputStream());
             if (image == null) {
@@ -131,9 +128,12 @@ public class AwsS3Service implements StorageService {
 
             BufferedImage imageNoAlpha = marvinImage.getBufferedImageNoAlpha();
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ImageIO.write(imageNoAlpha, imgFormat, baos);
+            if (!ImageIO.write(imageNoAlpha, imgFormat, baos)) {
+                throw invalidImageRequest();
+            }
             baos.flush();
-            return new MockMultipartFile(thumbnailImgName, baos.toByteArray());
+            byte[] bytes = baos.toByteArray();
+            return new ThumbnailImage(bytes, bytes.length, contentTypeForFormat(imgFormat));
         } catch (IOException e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Fail to generate thumbnail");
         }
@@ -287,5 +287,8 @@ public class AwsS3Service implements StorageService {
         return s3Client.utilities()
                 .getUrl(GetUrlRequest.builder().bucket(bucket).key(key).build())
                 .toExternalForm();
+    }
+
+    private record ThumbnailImage(byte[] bytes, long size, String contentType) {
     }
 }

--- a/src/test/java/com/mogak/spring/service/AwsS3ServiceTest.java
+++ b/src/test/java/com/mogak/spring/service/AwsS3ServiceTest.java
@@ -1,6 +1,7 @@
 package com.mogak.spring.service;
 
 import com.mogak.spring.global.ErrorCode;
+import com.mogak.spring.service.result.UploadedPostImageResult;
 import com.mogak.spring.support.ErrorCodeAssertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,6 +66,31 @@ class AwsS3ServiceTest {
         Throwable throwable = catchThrowable(() -> awsS3Service.uploadImg(List.of(), "img"));
 
         ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.NOT_HAVE_IMAGE);
+    }
+
+    @Test
+    @DisplayName("게시글 이미지 업로드는 첫 이미지 원본과 썸네일을 S3에 업로드한다")
+    void uploadImgUploadsOriginalAndThumbnailForFirstImage() throws Exception {
+        MockMultipartFile file = pngFile("post.png");
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+        when(s3Client.utilities()).thenReturn(s3Utilities);
+        doReturn(URI.create("https://example.com/post.png").toURL())
+                .when(s3Utilities)
+                .getUrl(any(GetUrlRequest.class));
+        ArgumentCaptor<PutObjectRequest> putCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+
+        List<UploadedPostImageResult> results = awsS3Service.uploadImg(List.of(file), "img");
+
+        verify(s3Client, times(2)).putObject(putCaptor.capture(), any(RequestBody.class));
+        assertThat(putCaptor.getAllValues())
+                .extracting(PutObjectRequest::contentType)
+                .containsExactly("image/png", "image/png");
+        assertThat(putCaptor.getAllValues().get(0).contentLength()).isEqualTo(file.getSize());
+        assertThat(putCaptor.getAllValues().get(1).contentLength()).isPositive();
+        assertThat(results)
+                .extracting(UploadedPostImageResult::isThumbnail)
+                .containsExactly(false, true);
     }
 
     @Test

--- a/src/test/java/com/mogak/spring/service/DisabledStorageServiceTest.java
+++ b/src/test/java/com/mogak/spring/service/DisabledStorageServiceTest.java
@@ -1,0 +1,53 @@
+package com.mogak.spring.service;
+
+import com.mogak.spring.global.ErrorCode;
+import com.mogak.spring.support.ErrorCodeAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+class DisabledStorageServiceTest {
+
+    private final DisabledStorageService disabledStorageService = new DisabledStorageService();
+
+    @Test
+    @DisplayName("게시글 이미지 업로드는 storage 비활성화 예외를 반환한다")
+    void uploadImgThrowsStorageDisabled() {
+        Throwable throwable = catchThrowable(() -> disabledStorageService.uploadImg(null, "img"));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.STORAGE_DISABLED);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 업로드는 storage 비활성화 예외를 반환한다")
+    void uploadProfileImgThrowsStorageDisabled() {
+        Throwable throwable = catchThrowable(() -> disabledStorageService.uploadProfileImg(null, "profile"));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.STORAGE_DISABLED);
+    }
+
+    @Test
+    @DisplayName("게시글 이미지 삭제는 storage 비활성화 예외를 반환한다")
+    void deleteImgThrowsStorageDisabled() {
+        Throwable throwable = catchThrowable(() -> disabledStorageService.deleteImg(null, "img"));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.STORAGE_DISABLED);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 삭제는 storage 비활성화 예외를 반환한다")
+    void deleteProfileImgThrowsStorageDisabled() {
+        Throwable throwable = catchThrowable(() -> disabledStorageService.deleteProfileImg("profile.png"));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.STORAGE_DISABLED);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 갱신은 storage 비활성화 예외를 반환한다")
+    void updateProfileImgThrowsStorageDisabled() {
+        Throwable throwable = catchThrowable(() -> disabledStorageService.updateProfileImg(null, "profile.png", "profile"));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.STORAGE_DISABLED);
+    }
+}

--- a/src/test/java/com/mogak/spring/service/StorageServiceConditionTest.java
+++ b/src/test/java/com/mogak/spring/service/StorageServiceConditionTest.java
@@ -1,0 +1,59 @@
+package com.mogak.spring.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StorageServiceConditionTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(StorageServiceConditionTest.TestConfig.class);
+
+    @Test
+    @DisplayName("feature.storage.enabled가 없거나 false면 DisabledStorageService가 StorageService로 등록된다")
+    void wiresDisabledStorageServiceWhenFeatureIsMissingOrFalse() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(StorageService.class);
+            assertThat(context.getBean(StorageService.class)).isInstanceOf(DisabledStorageService.class);
+            assertThat(context).hasSingleBean(DisabledStorageService.class);
+            assertThat(context).doesNotHaveBean(AwsS3Service.class);
+        });
+
+        contextRunner
+                .withPropertyValues("feature.storage.enabled=false")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(StorageService.class);
+                    assertThat(context.getBean(StorageService.class)).isInstanceOf(DisabledStorageService.class);
+                    assertThat(context).hasSingleBean(DisabledStorageService.class);
+                    assertThat(context).doesNotHaveBean(AwsS3Service.class);
+                });
+    }
+
+    @Test
+    @DisplayName("feature.storage.enabled=true면 S3Client와 bucket 설정이 있을 때 AwsS3Service가 StorageService로 등록된다")
+    void wiresAwsS3ServiceWhenFeatureEnabled() {
+        contextRunner
+                .withBean(S3Client.class, () -> Mockito.mock(S3Client.class))
+                .withPropertyValues(
+                        "feature.storage.enabled=true",
+                        "spring.cloud.aws.s3.bucket=test-bucket"
+                )
+                .run(context -> {
+                    assertThat(context).hasSingleBean(StorageService.class);
+                    assertThat(context.getBean(StorageService.class)).isInstanceOf(AwsS3Service.class);
+                    assertThat(context).hasSingleBean(AwsS3Service.class);
+                    assertThat(context).doesNotHaveBean(DisabledStorageService.class);
+                });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @Import({AwsS3Service.class, DisabledStorageService.class})
+    static class TestConfig {
+    }
+}

--- a/src/test/java/com/mogak/spring/service/StorageServiceConditionTest.java
+++ b/src/test/java/com/mogak/spring/service/StorageServiceConditionTest.java
@@ -4,8 +4,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class StorageServiceConditionTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-            .withUserConfiguration(StorageServiceConditionTest.TestConfig.class);
+            .withUserConfiguration(AwsS3Service.class, DisabledStorageService.class);
 
     @Test
     @DisplayName("feature.storage.enabled가 없거나 false면 DisabledStorageService가 StorageService로 등록된다")
@@ -52,8 +50,4 @@ class StorageServiceConditionTest {
                 });
     }
 
-    @Configuration(proxyBeanMethods = false)
-    @Import({AwsS3Service.class, DisabledStorageService.class})
-    static class TestConfig {
-    }
 }


### PR DESCRIPTION
## Summary

- `AwsS3Service` production 코드에서 `MockMultipartFile` 사용을 제거했습니다.
- 썸네일 생성 결과를 private `ThumbnailImage` record로 다루도록 변경했습니다.
- `ImageIO.write(...)` 실패 반환값을 확인해 빈 썸네일 업로드를 방지했습니다.
- `spring-test`를 runtime `implementation` 의존성에서 제거했습니다.
- storage disabled/enabled 경계와 S3 업로드 경로 테스트를 보강했습니다.

## Tests

- `sh gradlew test --tests com.mogak.spring.service.AwsS3ServiceTest --tests com.mogak.spring.service.DisabledStorageServiceTest --tests com.mogak.spring.service.StorageServiceConditionTest`
- `sh gradlew dependencyInsight --dependency org.springframework:spring-test --configuration runtimeClasspath`
  - 결과: `No dependencies matching given input were found`
- `sh gradlew test`

## Risk

- `StorageService` public API와 HTTP 계약은 변경하지 않았습니다.
- S3 client는 기존 SDK 경로를 그대로 사용하며, #128 credential chain 동작은 건드리지 않았습니다.
- `webp`처럼 런타임 ImageIO writer가 없는 포맷은 이제 빈 파일 업로드 대신 invalid image 흐름으로 실패할 수 있습니다.

## Follow-up

- 실제 `webp` 지원이 필요하면 ImageIO writer 플러그인 도입 또는 지원 포맷 정책 정리가 별도 이슈로 필요합니다.

Closes #138