### PR TITLE
feat: add marketing consent API

### DIFF
--- a/docs/operations/policies/ERD_DECISIONS_AND_LIFECYCLE.md
+++ b/docs/operations/policies/ERD_DECISIONS_AND_LIFECYCLE.md
@@ -31,7 +31,7 @@
 | `BlockUser` | hard delete | 차단 관계는 하드 삭제한다. |
 | `Report` | preserve | 신고 데이터는 보존한다. |
 | `ConsentItem` | preserve | 동의 항목 정의 데이터는 보존한다. |
-| `UserConsent` | pending | 사용자별 terms consent 상태로 유지하며, retention/anonymization/deletion policy는 pending이다. |
+| `UserConsent` | pending | 사용자별 동의 상태로 유지하며, retention/anonymization/deletion policy는 pending이다. |
 
 ## DailyJogak Creation Rules
 - routine midnight batch는 오늘자 `DailyJogak` row를 생성한다.

--- a/src/main/java/com/mogak/spring/domain/consent/UserConsent.java
+++ b/src/main/java/com/mogak/spring/domain/consent/UserConsent.java
@@ -63,6 +63,7 @@ public class UserConsent extends BaseEntity {
             this.withdrawnAt = null;
             return;
         }
+        this.agreedAt = null;
         this.withdrawnAt = changedAt;
     }
 }

--- a/src/main/java/com/mogak/spring/repository/ConsentItemRepository.java
+++ b/src/main/java/com/mogak/spring/repository/ConsentItemRepository.java
@@ -1,9 +1,12 @@
 package com.mogak.spring.repository;
 
 import com.mogak.spring.domain.consent.ConsentItem;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ConsentItemRepository extends JpaRepository<ConsentItem, Long> {
     List<ConsentItem> findAllByActiveTrueOrderByIdAsc();
+
+    List<ConsentItem> findAllByCodeInAndActiveTrue(Collection<String> codes);
 }

--- a/src/main/java/com/mogak/spring/repository/UserConsentRepository.java
+++ b/src/main/java/com/mogak/spring/repository/UserConsentRepository.java
@@ -1,6 +1,7 @@
 package com.mogak.spring.repository;
 
 import com.mogak.spring.domain.consent.UserConsent;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,6 @@ public interface UserConsentRepository extends JpaRepository<UserConsent, Long> 
     Optional<UserConsent> findByUserIdAndConsentItemId(Long userId, Long consentItemId);
 
     List<UserConsent> findAllByUserId(Long userId);
+
+    List<UserConsent> findAllByUserIdAndConsentItemCodeIn(Long userId, Collection<String> codes);
 }

--- a/src/main/java/com/mogak/spring/service/ConsentService.java
+++ b/src/main/java/com/mogak/spring/service/ConsentService.java
@@ -1,8 +1,10 @@
 package com.mogak.spring.service;
 
 import com.mogak.spring.domain.user.User;
+import com.mogak.spring.service.command.MarketingConsentCommand;
 import com.mogak.spring.service.command.UserConsentCommand;
 import com.mogak.spring.service.result.ConsentItemResult;
+import com.mogak.spring.service.result.MarketingConsentResult;
 import java.util.List;
 
 public interface ConsentService {
@@ -11,4 +13,8 @@ public interface ConsentService {
     void saveUserConsents(User user, List<UserConsentCommand> consents);
 
     void updateUserConsents(Long userId, List<UserConsentCommand> consents);
+
+    MarketingConsentResult getMarketingConsent(Long userId);
+
+    MarketingConsentResult updateMarketingConsent(Long userId, MarketingConsentCommand command);
 }

--- a/src/main/java/com/mogak/spring/service/ConsentServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/ConsentServiceImpl.java
@@ -92,8 +92,12 @@ public class ConsentServiceImpl implements ConsentService {
         Map<String, UserConsent> userConsents = findUserConsentsByCode(userId, requestedCodes);
         LocalDateTime now = LocalDateTime.now();
 
-        updateMarketingConsent(user, command.marketingAgreed(), MARKETING_CODE, consentItems, userConsents, now);
-        updateMarketingConsent(user, command.advertisementAgreed(), ADVERTISEMENT_CODE, consentItems, userConsents, now);
+        if (command.marketingAgreed() != null) {
+            updateMarketingConsent(user, command.marketingAgreed(), MARKETING_CODE, consentItems, userConsents, now);
+        }
+        if (command.advertisementAgreed() != null) {
+            updateMarketingConsent(user, command.advertisementAgreed(), ADVERTISEMENT_CODE, consentItems, userConsents, now);
+        }
 
         return getCurrentMarketingConsent(userId);
     }
@@ -203,10 +207,6 @@ public class ConsentServiceImpl implements ConsentService {
             Map<String, UserConsent> userConsents,
             LocalDateTime now
     ) {
-        if (agreed == null) {
-            return;
-        }
-
         UserConsent userConsent = userConsents.get(code);
         if (userConsent == null) {
             userConsent = UserConsent.builder()

--- a/src/main/java/com/mogak/spring/service/ConsentServiceImpl.java
+++ b/src/main/java/com/mogak/spring/service/ConsentServiceImpl.java
@@ -8,8 +8,12 @@ import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.repository.ConsentItemRepository;
 import com.mogak.spring.repository.UserConsentRepository;
 import com.mogak.spring.repository.UserRepository;
+import com.mogak.spring.service.command.MarketingConsentCommand;
 import com.mogak.spring.service.command.UserConsentCommand;
 import com.mogak.spring.service.result.ConsentItemResult;
+import com.mogak.spring.service.result.MarketingConsentResult;
+import java.util.Collection;
+import java.util.HashMap;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -24,6 +28,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class ConsentServiceImpl implements ConsentService {
+    private static final String MARKETING_CODE = "MARKETING";
+    private static final String ADVERTISEMENT_CODE = "ADVERTISEMENT";
+    private static final List<String> MARKETING_CONSENT_CODES = List.of(
+            MARKETING_CODE,
+            ADVERTISEMENT_CODE
+    );
+
     private final ConsentItemRepository consentItemRepository;
     private final UserConsentRepository userConsentRepository;
     private final UserRepository userRepository;
@@ -42,6 +53,13 @@ public class ConsentServiceImpl implements ConsentService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public MarketingConsentResult getMarketingConsent(Long userId) {
+        validateActiveUser(userId);
+        return getCurrentMarketingConsent(userId);
+    }
+
     @Transactional
     @Override
     public void saveUserConsents(User user, List<UserConsentCommand> consents) {
@@ -54,12 +72,30 @@ public class ConsentServiceImpl implements ConsentService {
     @Transactional
     @Override
     public void updateUserConsents(Long userId, List<UserConsentCommand> consents) {
-        User user = userRepository.findActiveById(userId)
-                .orElseThrow(() -> new BaseException(ErrorCode.NOT_EXIST_USER));
+        User user = validateActiveUser(userId);
         if (consents == null || consents.isEmpty()) {
             return;
         }
         upsertUserConsents(user, consents);
+    }
+
+    @Transactional
+    @Override
+    public MarketingConsentResult updateMarketingConsent(Long userId, MarketingConsentCommand command) {
+        if (command == null || command.isEmpty()) {
+            throw new BaseException(ErrorCode.INVALID_PARAMETER_ERROR);
+        }
+
+        User user = validateActiveUser(userId);
+        List<String> requestedCodes = requestedCodes(command);
+        Map<String, ConsentItem> consentItems = findActiveConsentItemsByCode(requestedCodes);
+        Map<String, UserConsent> userConsents = findUserConsentsByCode(userId, requestedCodes);
+        LocalDateTime now = LocalDateTime.now();
+
+        updateMarketingConsent(user, command.marketingAgreed(), MARKETING_CODE, consentItems, userConsents, now);
+        updateMarketingConsent(user, command.advertisementAgreed(), ADVERTISEMENT_CODE, consentItems, userConsents, now);
+
+        return getCurrentMarketingConsent(userId);
     }
 
     private void upsertUserConsents(User user, List<UserConsentCommand> consents) {
@@ -109,5 +145,76 @@ public class ConsentServiceImpl implements ConsentService {
                 .toList();
         return consentItemRepository.findAllById(ids).stream()
                 .collect(Collectors.toMap(ConsentItem::getId, Function.identity()));
+    }
+
+    private User validateActiveUser(Long userId) {
+        return userRepository.findActiveById(userId)
+                .orElseThrow(() -> new BaseException(ErrorCode.NOT_EXIST_USER));
+    }
+
+    private MarketingConsentResult getCurrentMarketingConsent(Long userId) {
+        Map<String, UserConsent> userConsents = findUserConsentsByCode(userId, MARKETING_CONSENT_CODES);
+        return new MarketingConsentResult(
+                agreed(userConsents, MARKETING_CODE),
+                agreed(userConsents, ADVERTISEMENT_CODE)
+        );
+    }
+
+    private boolean agreed(Map<String, UserConsent> userConsents, String code) {
+        UserConsent userConsent = userConsents.get(code);
+        return userConsent != null && userConsent.isAgreed();
+    }
+
+    private List<String> requestedCodes(MarketingConsentCommand command) {
+        return MARKETING_CONSENT_CODES.stream()
+                .filter(code -> {
+                    if (MARKETING_CODE.equals(code)) {
+                        return command.marketingAgreed() != null;
+                    }
+                    if (ADVERTISEMENT_CODE.equals(code)) {
+                        return command.advertisementAgreed() != null;
+                    }
+                    return false;
+                })
+                .toList();
+    }
+
+    private Map<String, ConsentItem> findActiveConsentItemsByCode(Collection<String> codes) {
+        Map<String, ConsentItem> consentItems = consentItemRepository.findAllByCodeInAndActiveTrue(codes).stream()
+                .collect(Collectors.toMap(ConsentItem::getCode, Function.identity()));
+        if (consentItems.size() != codes.size()) {
+            throw new BaseException(ErrorCode.NOT_EXIST_CONSENT_ITEM);
+        }
+        return consentItems;
+    }
+
+    private Map<String, UserConsent> findUserConsentsByCode(Long userId, Collection<String> codes) {
+        Map<String, UserConsent> userConsents = new HashMap<>();
+        userConsentRepository.findAllByUserIdAndConsentItemCodeIn(userId, codes)
+                .forEach(userConsent -> userConsents.put(userConsent.getConsentItem().getCode(), userConsent));
+        return userConsents;
+    }
+
+    private void updateMarketingConsent(
+            User user,
+            Boolean agreed,
+            String code,
+            Map<String, ConsentItem> consentItems,
+            Map<String, UserConsent> userConsents,
+            LocalDateTime now
+    ) {
+        if (agreed == null) {
+            return;
+        }
+
+        UserConsent userConsent = userConsents.get(code);
+        if (userConsent == null) {
+            userConsent = UserConsent.builder()
+                    .user(user)
+                    .consentItem(consentItems.get(code))
+                    .build();
+            userConsentRepository.save(userConsent);
+        }
+        userConsent.update(agreed, now);
     }
 }

--- a/src/main/java/com/mogak/spring/service/command/MarketingConsentCommand.java
+++ b/src/main/java/com/mogak/spring/service/command/MarketingConsentCommand.java
@@ -1,0 +1,10 @@
+package com.mogak.spring.service.command;
+
+public record MarketingConsentCommand(
+        Boolean marketingAgreed,
+        Boolean advertisementAgreed
+) {
+    public boolean isEmpty() {
+        return marketingAgreed == null && advertisementAgreed == null;
+    }
+}

--- a/src/main/java/com/mogak/spring/service/result/MarketingConsentResult.java
+++ b/src/main/java/com/mogak/spring/service/result/MarketingConsentResult.java
@@ -1,0 +1,7 @@
+package com.mogak.spring.service.result;
+
+public record MarketingConsentResult(
+        boolean marketingAgreed,
+        boolean advertisementAgreed
+) {
+}

--- a/src/main/java/com/mogak/spring/web/controller/ConsentController.java
+++ b/src/main/java/com/mogak/spring/web/controller/ConsentController.java
@@ -4,7 +4,10 @@ import com.mogak.spring.global.BaseResponse;
 import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.jwt.AuthenticatedUser;
 import com.mogak.spring.service.ConsentService;
+import com.mogak.spring.service.result.MarketingConsentResult;
 import com.mogak.spring.web.dto.consentdto.ConsentItemResponse;
+import com.mogak.spring.web.dto.consentdto.MarketingConsentPatchRequest;
+import com.mogak.spring.web.dto.consentdto.MarketingConsentResponse;
 import com.mogak.spring.web.dto.consentdto.UserConsentUpdateRequest;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -12,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,6 +34,14 @@ public class ConsentController {
         return ResponseEntity.ok(new BaseResponse<>(responses));
     }
 
+    @GetMapping("/api/users/marketing-consent")
+    public ResponseEntity<BaseResponse<MarketingConsentResponse>> getMarketingConsent(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser
+    ) {
+        MarketingConsentResult result = consentService.getMarketingConsent(authenticatedUser.getUserId());
+        return ResponseEntity.ok(new BaseResponse<>(MarketingConsentResponse.from(result)));
+    }
+
     @PutMapping("/api/users/consents")
     public ResponseEntity<BaseResponse<ErrorCode>> updateUserConsents(
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
@@ -37,5 +49,17 @@ public class ConsentController {
     ) {
         consentService.updateUserConsents(authenticatedUser.getUserId(), request.toCommands());
         return ResponseEntity.ok(new BaseResponse<>(ErrorCode.SUCCESS));
+    }
+
+    @PatchMapping("/api/users/marketing-consent")
+    public ResponseEntity<BaseResponse<MarketingConsentResponse>> updateMarketingConsent(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            @Valid @RequestBody MarketingConsentPatchRequest request
+    ) {
+        MarketingConsentResult result = consentService.updateMarketingConsent(
+                authenticatedUser.getUserId(),
+                request.toCommand()
+        );
+        return ResponseEntity.ok(new BaseResponse<>(MarketingConsentResponse.from(result)));
     }
 }

--- a/src/main/java/com/mogak/spring/web/dto/consentdto/MarketingConsentPatchRequest.java
+++ b/src/main/java/com/mogak/spring/web/dto/consentdto/MarketingConsentPatchRequest.java
@@ -1,0 +1,18 @@
+package com.mogak.spring.web.dto.consentdto;
+
+import com.mogak.spring.service.command.MarketingConsentCommand;
+import jakarta.validation.constraints.AssertTrue;
+
+public record MarketingConsentPatchRequest(
+        Boolean marketingAgreed,
+        Boolean advertisementAgreed
+) {
+    @AssertTrue(message = "변경할 동의 값을 입력해주세요.")
+    public boolean hasAnyAgreement() {
+        return marketingAgreed != null || advertisementAgreed != null;
+    }
+
+    public MarketingConsentCommand toCommand() {
+        return new MarketingConsentCommand(marketingAgreed, advertisementAgreed);
+    }
+}

--- a/src/main/java/com/mogak/spring/web/dto/consentdto/MarketingConsentResponse.java
+++ b/src/main/java/com/mogak/spring/web/dto/consentdto/MarketingConsentResponse.java
@@ -1,0 +1,12 @@
+package com.mogak.spring.web.dto.consentdto;
+
+import com.mogak.spring.service.result.MarketingConsentResult;
+
+public record MarketingConsentResponse(
+        boolean marketingAgreed,
+        boolean advertisementAgreed
+) {
+    public static MarketingConsentResponse from(MarketingConsentResult result) {
+        return new MarketingConsentResponse(result.marketingAgreed(), result.advertisementAgreed());
+    }
+}

--- a/src/test/java/com/mogak/spring/config/SecurityConfigTest.java
+++ b/src/test/java/com/mogak/spring/config/SecurityConfigTest.java
@@ -52,6 +52,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -202,6 +203,24 @@ class SecurityConfigTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value("success"))
                 .andExpect(jsonPath("$.result[0].code").value("MARKETING"));
+    }
+
+    @Test
+    @DisplayName("광고/마케팅 동의 조회 API는 토큰 없이 호출하면 401을 반환한다")
+    void marketingConsentGetRejectsMissingToken() throws Exception {
+        mockMvc.perform(get("/api/users/marketing-consent"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("T003"));
+    }
+
+    @Test
+    @DisplayName("광고/마케팅 동의 변경 API는 토큰 없이 호출하면 401을 반환한다")
+    void marketingConsentPatchRejectsMissingToken() throws Exception {
+        mockMvc.perform(patch("/api/users/marketing-consent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"marketingAgreed\":true}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("T003"));
     }
 
     private org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder joinRequest(String role)

--- a/src/test/java/com/mogak/spring/service/ConsentServiceImplTest.java
+++ b/src/test/java/com/mogak/spring/service/ConsentServiceImplTest.java
@@ -7,8 +7,10 @@ import com.mogak.spring.global.ErrorCode;
 import com.mogak.spring.repository.ConsentItemRepository;
 import com.mogak.spring.repository.UserConsentRepository;
 import com.mogak.spring.repository.UserRepository;
+import com.mogak.spring.service.command.MarketingConsentCommand;
 import com.mogak.spring.service.command.UserConsentCommand;
 import com.mogak.spring.service.result.ConsentItemResult;
+import com.mogak.spring.service.result.MarketingConsentResult;
 import com.mogak.spring.support.ErrorCodeAssertions;
 import com.mogak.spring.support.TestFixtureFactory;
 import java.util.ArrayList;
@@ -24,7 +26,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,6 +60,44 @@ class ConsentServiceImplTest {
     }
 
     @Test
+    @DisplayName("저장된 광고와 마케팅 동의 상태를 반환한다")
+    void getMarketingConsentReturnsSavedState() {
+        User user = TestFixtureFactory.user(10L, "user@test.com", "tester", null, null);
+        ConsentItem marketing = consentItem(1L, "MARKETING", true, false);
+        ConsentItem advertisement = consentItem(2L, "ADVERTISEMENT", true, false);
+        UserConsent marketingConsent = userConsent(user, marketing, true);
+        UserConsent advertisementConsent = userConsent(user, advertisement, false);
+
+        when(userRepository.findActiveById(10L)).thenReturn(Optional.of(user));
+        when(userConsentRepository.findAllByUserIdAndConsentItemCodeIn(
+                10L,
+                List.of("MARKETING", "ADVERTISEMENT")
+        )).thenReturn(List.of(marketingConsent, advertisementConsent));
+
+        MarketingConsentResult result = consentService.getMarketingConsent(10L);
+
+        assertThat(result.marketingAgreed()).isTrue();
+        assertThat(result.advertisementAgreed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("저장된 동의가 없으면 광고와 마케팅 동의 상태를 false로 반환한다")
+    void getMarketingConsentDefaultsToFalse() {
+        User user = TestFixtureFactory.user(10L, "user@test.com", "tester", null, null);
+
+        when(userRepository.findActiveById(10L)).thenReturn(Optional.of(user));
+        when(userConsentRepository.findAllByUserIdAndConsentItemCodeIn(
+                10L,
+                List.of("MARKETING", "ADVERTISEMENT")
+        )).thenReturn(List.of());
+
+        MarketingConsentResult result = consentService.getMarketingConsent(10L);
+
+        assertThat(result.marketingAgreed()).isFalse();
+        assertThat(result.advertisementAgreed()).isFalse();
+    }
+
+    @Test
     @DisplayName("신규 사용자 동의 상태를 저장한다")
     void saveUserConsentsCreatesUserConsent() {
         User user = TestFixtureFactory.user(10L, "user@test.com", "tester", null, null);
@@ -79,6 +118,37 @@ class ConsentServiceImplTest {
     }
 
     @Test
+    @DisplayName("마케팅 동의만 들어오면 마케팅 동의만 생성하고 광고 동의는 기존 상태를 유지한다")
+    void updateMarketingConsentUpdatesOnlyRequestedField() {
+        User user = TestFixtureFactory.user(10L, "user@test.com", "tester", null, null);
+        ConsentItem marketing = consentItem(1L, "MARKETING", true, false);
+
+        when(userRepository.findActiveById(10L)).thenReturn(Optional.of(user));
+        when(consentItemRepository.findAllByCodeInAndActiveTrue(List.of("MARKETING")))
+                .thenReturn(List.of(marketing));
+        when(userConsentRepository.findAllByUserIdAndConsentItemCodeIn(
+                10L,
+                List.of("MARKETING")
+        )).thenReturn(List.of());
+        when(userConsentRepository.findAllByUserIdAndConsentItemCodeIn(
+                10L,
+                List.of("MARKETING", "ADVERTISEMENT")
+        )).thenReturn(List.of(userConsent(user, marketing, true)));
+
+        MarketingConsentResult result = consentService.updateMarketingConsent(
+                10L,
+                new MarketingConsentCommand(true, null)
+        );
+
+        ArgumentCaptor<UserConsent> captor = ArgumentCaptor.forClass(UserConsent.class);
+        verify(userConsentRepository).save(captor.capture());
+        assertThat(captor.getValue().getConsentItem()).isEqualTo(marketing);
+        assertThat(captor.getValue().isAgreed()).isTrue();
+        assertThat(result.marketingAgreed()).isTrue();
+        assertThat(result.advertisementAgreed()).isFalse();
+    }
+
+    @Test
     @DisplayName("기존 사용자 동의 상태를 철회 상태로 갱신한다")
     void updateUserConsentsUpdatesExistingUserConsent() {
         User user = TestFixtureFactory.user(10L, "user@test.com", "tester", null, null);
@@ -94,8 +164,20 @@ class ConsentServiceImplTest {
         consentService.updateUserConsents(10L, List.of(new UserConsentCommand(1L, false)));
 
         assertThat(existing.isAgreed()).isFalse();
+        assertThat(existing.getAgreedAt()).isNull();
         assertThat(existing.getWithdrawnAt()).isNotNull();
         verify(userConsentRepository, never()).save(existing);
+    }
+
+    @Test
+    @DisplayName("변경할 광고/마케팅 동의 값이 없으면 실패한다")
+    void updateMarketingConsentRejectsEmptyCommand() {
+        Throwable throwable = catchThrowable(() -> consentService.updateMarketingConsent(
+                10L,
+                new MarketingConsentCommand(null, null)
+        ));
+
+        ErrorCodeAssertions.assertErrorCode(throwable, ErrorCode.INVALID_PARAMETER_ERROR);
     }
 
     @Test
@@ -160,5 +242,14 @@ class ConsentServiceImplTest {
                 .active(active)
                 .required(required)
                 .build();
+    }
+
+    private UserConsent userConsent(User user, ConsentItem consentItem, boolean agreed) {
+        UserConsent consent = UserConsent.builder()
+                .user(user)
+                .consentItem(consentItem)
+                .build();
+        consent.update(agreed, java.time.LocalDateTime.now());
+        return consent;
     }
 }

--- a/src/test/java/com/mogak/spring/web/controller/ConsentControllerTest.java
+++ b/src/test/java/com/mogak/spring/web/controller/ConsentControllerTest.java
@@ -4,8 +4,10 @@ import com.mogak.spring.exception.GlobalExceptionHandler;
 import com.mogak.spring.jwt.JwtTokenProvider;
 import com.mogak.spring.security.SecurityAuthority;
 import com.mogak.spring.service.ConsentService;
+import com.mogak.spring.service.command.MarketingConsentCommand;
 import com.mogak.spring.service.command.UserConsentCommand;
 import com.mogak.spring.service.result.ConsentItemResult;
+import com.mogak.spring.service.result.MarketingConsentResult;
 import com.mogak.spring.support.SecurityContextTestHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -24,12 +26,14 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -82,6 +86,24 @@ class ConsentControllerTest {
     }
 
     @Test
+    @DisplayName("현재 사용자의 광고와 마케팅 동의 상태를 조회한다")
+    void getMarketingConsentContract() throws Exception {
+        SecurityContextTestHelper.setAuthentication(10L, "user@test.com", SecurityAuthority.USER.getAuthority());
+        when(consentService.getMarketingConsent(10L))
+                .thenReturn(new MarketingConsentResult(true, false));
+
+        mockMvc.perform(get("/api/users/marketing-consent"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.time").exists())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.code").value("success"))
+                .andExpect(jsonPath("$.message").value("요청에 성공했습니다."))
+                .andExpect(jsonPath("$.result.marketingAgreed").value(true))
+                .andExpect(jsonPath("$.result.advertisementAgreed").value(false));
+    }
+
+    @Test
     @DisplayName("사용자 동의 변경 요청은 인증 유저와 동의 목록을 서비스로 전달한다")
     void updateUserConsentsForwardsAuthenticatedUserAndAgreements() throws Exception {
         SecurityContextTestHelper.setAuthentication(10L, "user@test.com", SecurityAuthority.USER.getAuthority());
@@ -105,6 +127,27 @@ class ConsentControllerTest {
     }
 
     @Test
+    @DisplayName("현재 사용자의 광고와 마케팅 동의 상태 중 요청된 값만 변경한다")
+    void patchMarketingConsentContract() throws Exception {
+        SecurityContextTestHelper.setAuthentication(10L, "user@test.com", SecurityAuthority.USER.getAuthority());
+        when(consentService.updateMarketingConsent(anyLong(), any(MarketingConsentCommand.class)))
+                .thenReturn(new MarketingConsentResult(true, false));
+
+        mockMvc.perform(patch("/api/users/marketing-consent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"marketingAgreed\":true}"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.result.marketingAgreed").value(true))
+                .andExpect(jsonPath("$.result.advertisementAgreed").value(false));
+
+        ArgumentCaptor<MarketingConsentCommand> captor = ArgumentCaptor.forClass(MarketingConsentCommand.class);
+        verify(consentService).updateMarketingConsent(org.mockito.Mockito.eq(10L), captor.capture());
+        assertThat(captor.getValue().marketingAgreed()).isTrue();
+        assertThat(captor.getValue().advertisementAgreed()).isNull();
+    }
+
+    @Test
     @DisplayName("사용자 동의 변경 요청에 null 항목이 있으면 400을 반환한다")
     void updateUserConsentsRejectsNullAgreementItem() throws Exception {
         SecurityContextTestHelper.setAuthentication(10L, "user@test.com", SecurityAuthority.USER.getAuthority());
@@ -118,5 +161,19 @@ class ConsentControllerTest {
                 .andExpect(jsonPath("$.code").value("Z005"));
 
         verify(consentService, never()).updateUserConsents(anyLong(), anyList());
+    }
+
+    @Test
+    @DisplayName("변경할 동의 값이 없는 요청은 400을 반환한다")
+    void patchMarketingConsentRejectsEmptyRequest() throws Exception {
+        SecurityContextTestHelper.setAuthentication(10L, "user@test.com", SecurityAuthority.USER.getAuthority());
+
+        mockMvc.perform(patch("/api/users/marketing-consent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("Z005"));
+
+        verify(consentService, never()).updateMarketingConsent(anyLong(), any());
     }
 }


### PR DESCRIPTION
## Summary
- 광고/마케팅 동의 조회 API를 추가했습니다.
- 광고/마케팅 동의 일부 변경을 위한 PATCH API를 추가했습니다.
- 기존 AgreeUser/user_agree 레거시 모델을 ConsentItem/UserConsent 모델로 대체했습니다.
- 동의 모델 변경에 맞춰 baseline/seed SQL과 ERD lifecycle 문서를 갱신했습니다.

## Tests
- sh gradlew test
- code-review-helper: concrete finding 없음
- final-review: 완료 가능하지만 운영 DB migration 적용 순서 risk 있음

## Risk
- 운영 DB가 이미 존재하는 환경에서는 user_agree 제거 및 consent_item/user_consent 추가를 위한 별도 마이그레이션 적용 순서 확인이 필요합니다.
- 기존 untracked 작업 디렉터리들은 이번 PR 범위에서 제외했습니다.

## Follow-up
- 운영 배포 시 DB migration 파일/절차가 필요한지 확인해야 합니다.